### PR TITLE
Add access user and symbol map parsing

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"time"
 	"unicode"
@@ -68,6 +69,8 @@ type File struct {
 	Comment          string
 	Access           bool
 	Symbols          bool
+	AccessUsers      []string
+	SymbolMap        map[string]string
 	Locks            []*Lock
 	RevisionHeads    []*RevisionHead
 	RevisionContents []*RevisionContent
@@ -77,10 +80,32 @@ func (f *File) String() string {
 	sb := strings.Builder{}
 	sb.WriteString(fmt.Sprintf("head\t%s;\n", f.Head))
 	if f.Access {
-		sb.WriteString("access;\n")
+		if len(f.AccessUsers) > 0 {
+			sb.WriteString("access ")
+			sb.WriteString(strings.Join(f.AccessUsers, " "))
+			sb.WriteString(";\n")
+		} else {
+			sb.WriteString("access;\n")
+		}
 	}
 	if f.Symbols {
-		sb.WriteString("symbols;\n")
+		if len(f.SymbolMap) > 0 {
+			sb.WriteString("symbols ")
+			keys := make([]string, 0, len(f.SymbolMap))
+			for k := range f.SymbolMap {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for i, k := range keys {
+				if i > 0 {
+					sb.WriteString(" ")
+				}
+				sb.WriteString(fmt.Sprintf("%s:%s", k, f.SymbolMap[k]))
+			}
+			sb.WriteString(";\n")
+		} else {
+			sb.WriteString("symbols;\n")
+		}
 	}
 	sb.WriteString("locks")
 	if len(f.Locks) == 0 {
@@ -200,15 +225,18 @@ func ParseHeader(s *Scanner, f *File) error {
 		switch nt {
 		case "access":
 			f.Access = true
-			err := ParseTerminatorFieldLine(s)
+			users, err := ParseHeaderAccess(s, true)
 			if err != nil {
 				return fmt.Errorf("token %#v: %w", nt, err)
 			}
+			f.AccessUsers = users
 		case "symbols":
 			f.Symbols = true
-			if err := ParseTerminatorFieldLine(s); err != nil {
+			sym, err := ParseHeaderSymbols(s, true)
+			if err != nil {
 				return fmt.Errorf("token %#v: %w", nt, err)
 			}
+			f.SymbolMap = sym
 		case "locks":
 			if locks, err := ParseHeaderLocks(s, true); err != nil {
 				return fmt.Errorf("token %#v: %w", nt, err)
@@ -372,6 +400,55 @@ func ParseHeaderComment(s *Scanner, havePropertyName bool) (string, error) {
 	}
 	return sr, nil
 
+}
+
+func ParseHeaderAccess(s *Scanner, havePropertyName bool) ([]string, error) {
+	if !havePropertyName {
+		if err := ScanStrings(s, "access"); err != nil {
+			return nil, err
+		}
+	}
+	if err := ScanWhiteSpace(s, 0); err != nil {
+		return nil, err
+	}
+	if err := ScanUntilFieldTerminator(s); err != nil {
+		return nil, err
+	}
+	text := s.Text()
+	if err := ParseTerminatorFieldLine(s); err != nil {
+		return nil, err
+	}
+	if text == "" {
+		return []string{}, nil
+	}
+	return strings.Fields(text), nil
+}
+
+func ParseHeaderSymbols(s *Scanner, havePropertyName bool) (map[string]string, error) {
+	if !havePropertyName {
+		if err := ScanStrings(s, "symbols"); err != nil {
+			return nil, err
+		}
+	}
+	if err := ScanWhiteSpace(s, 0); err != nil {
+		return nil, err
+	}
+	if err := ScanUntilNewLine(s); err != nil {
+		return nil, err
+	}
+	line := s.Text()
+	if err := ScanNewLine(s, false); err != nil {
+		return nil, err
+	}
+	m := map[string]string{}
+	for _, f := range strings.Fields(line) {
+		f = strings.TrimSuffix(f, ";")
+		parts := strings.SplitN(f, ":", 2)
+		if len(parts) == 2 {
+			m[parts[0]] = parts[1]
+		}
+	}
+	return m, nil
 }
 
 func ParseAtQuotedString(s *Scanner) (string, error) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -15,7 +15,31 @@ var (
 	//go:embed "testdata/testinput.go,v"
 	testinputv []byte
 	//go:embed "testdata/testinput1.go,v"
-	testinputv1 []byte
+	testinputv1   []byte
+	accessSymbols = []byte(
+		"head\t1.1;\n" +
+			"access john jane;\n" +
+			"symbols rel:1.1 tag:1.1.0.2;\n" +
+			"locks\n" +
+			"\tjohn:1.1;\n" +
+			"comment\t@# @;\n" +
+			"\n" +
+			"\n" +
+			"1.1\n" +
+			"date\t2024.01.01.00.00.00;\tauthor john;\tstate Exp;\n" +
+			"branches;\n" +
+			"next\t;\n" +
+			"\n" +
+			"\n" +
+			"desc\n" +
+			"@Sample\n@\n" +
+			"\n" +
+			"\n" +
+			"1.1\n" +
+			"log\n" +
+			"@init@\n" +
+			"text\n" +
+			"@hello@\n")
 )
 
 func TestParseFile(t *testing.T) {
@@ -37,6 +61,12 @@ func TestParseFile(t *testing.T) {
 			b:       testinputv1,
 			wantErr: false,
 		},
+		{
+			name:    "Parse file with access and symbols",
+			r:       string(accessSymbols),
+			b:       accessSymbols,
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -45,17 +75,30 @@ func TestParseFile(t *testing.T) {
 				t.Errorf("ParseFile() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if diff := cmp.Diff(got.Description, "This is a test file.\n"); diff != "" {
-				t.Errorf("Description: %s", diff)
-			}
-			if diff := cmp.Diff(len(got.Locks), 1); diff != "" {
-				t.Errorf("Locks: %s", diff)
-			}
-			if diff := cmp.Diff(len(got.RevisionHeads), 6); diff != "" {
-				t.Errorf("RevisionHeads: %s", diff)
-			}
-			if diff := cmp.Diff(len(got.RevisionContents), 6); diff != "" {
-				t.Errorf("RevisionContents: %s", diff)
+			if tt.name != "Parse file with access and symbols" {
+				if diff := cmp.Diff(got.Description, "This is a test file.\n"); diff != "" {
+					t.Errorf("Description: %s", diff)
+				}
+				if diff := cmp.Diff(len(got.Locks), 1); diff != "" {
+					t.Errorf("Locks: %s", diff)
+				}
+				if diff := cmp.Diff(len(got.RevisionHeads), 6); diff != "" {
+					t.Errorf("RevisionHeads: %s", diff)
+				}
+				if diff := cmp.Diff(len(got.RevisionContents), 6); diff != "" {
+					t.Errorf("RevisionContents: %s", diff)
+				}
+			} else {
+				if diff := cmp.Diff(got.AccessUsers, []string{"john", "jane"}); diff != "" {
+					t.Errorf("AccessUsers: %s", diff)
+				}
+				expectedMap := map[string]string{"rel": "1.1", "tag": "1.1.0.2"}
+				if diff := cmp.Diff(expectedMap, got.SymbolMap); diff != "" {
+					t.Errorf("SymbolMap: %s", diff)
+				}
+				if diff := cmp.Diff(got.Description, "Sample\n"); diff != "" {
+					t.Errorf("Description: %s", diff)
+				}
 			}
 			if diff := cmp.Diff(got.String(), string(tt.r)); diff != "" {
 				t.Errorf("String(): %s", diff)
@@ -113,10 +156,12 @@ func TestParseHeader(t *testing.T) {
 				s: NewScanner(bytes.NewReader(testinputv)),
 			},
 			want: &File{
-				Head:    "1.6",
-				Comment: "# ",
-				Access:  true,
-				Symbols: true,
+				Head:        "1.6",
+				Comment:     "# ",
+				Access:      true,
+				Symbols:     true,
+				AccessUsers: []string{},
+				SymbolMap:   map[string]string{},
 				Locks: []*Lock{
 					{
 						User:     "arran",


### PR DESCRIPTION
## Summary
- support access user list and symbol mappings
- emit access users and symbols in String output
- parse access users and symbols in headers
- test access and symbol parsing round-trip

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68482e1a73b8832fac70ec494f8d9e8b