### PR TITLE
Fix lint issues

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -119,7 +119,7 @@ func (f *File) String() string {
 }
 
 func AtQuote(s string) string {
-	return "@" + strings.Replace(s, "@", "@@", -1) + "@"
+	return "@" + strings.ReplaceAll(s, "@", "@@") + "@"
 }
 
 func ParseFile(r io.Reader) (*File, error) {

--- a/scanner.go
+++ b/scanner.go
@@ -61,7 +61,7 @@ type ScannerOpt interface {
 type MaxBuffer int
 
 func (mb MaxBuffer) ScannerOpt(scanner *Scanner) {
-	scanner.Scanner.Buffer(nil, int(mb))
+	scanner.Buffer(nil, int(mb))
 }
 
 func NewScanner(r io.Reader, opts ...ScannerOpt) *Scanner {
@@ -72,7 +72,7 @@ func NewScanner(r io.Reader, opts ...ScannerOpt) *Scanner {
 		},
 	}
 	scanner.Scanner.Split(scanner.scannerWrapper)
-	scanner.Scanner.Buffer(nil, math.MaxInt/2)
+	scanner.Buffer(nil, math.MaxInt/2)
 	for _, opt := range opts {
 		opt.ScannerOpt(scanner)
 	}


### PR DESCRIPTION
## Summary
- update AtQuote to use strings.ReplaceAll
- call Buffer directly on embedded scanner

## Testing
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6854de5c04d4832fa82d8bbfbbfb27b5