### PR TITLE
Update golangci-lint-action to avoid deprecated cache

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,6 +24,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v8
         with:
           version: latest


### PR DESCRIPTION
## Summary
- update golangci-lint-action from v2 to v8 so it uses a modern cache

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6854dd92f25c832f84ef5e995736dc03