### PR TITLE
Fix GitHub Actions cache

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Cache-Go
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.3
         with:
           path: |
             ~/go/pkg/mod              # Module download cache

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Cache-Go
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.3
         with:
           path: |
             ~/go/pkg/mod

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
     - name: Cache-Go
-      uses: actions/cache@v4
+      uses: actions/cache@v4.2.3
       with:
         path: |
           ~/go/pkg/mod              # Module download cache


### PR DESCRIPTION
## Summary
- lock cache version to actions/cache@v4.2.3

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6854dd83c6fc832f9cf34598afb0ca40