### PR TITLE
Remove unnecessary Cache-Go step from workflows

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,16 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Cache-Go
-        uses: actions/cache@v4.2.3
-        with:
-          path: |
-            ~/go/pkg/mod              # Module download cache
-            ~/.cache/go-build         # Build cache (Linux)
-            ~/Library/Caches/go-build # Build cache (Mac)
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -20,16 +20,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - name: Cache-Go
-        uses: actions/cache@v4.2.3
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-            ~/Library/Caches/go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
       - name: Test
         run: go test ./...
       - name: Run GoReleaser

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,16 +12,6 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
-    - name: Cache-Go
-      uses: actions/cache@v4.2.3
-      with:
-        path: |
-          ~/go/pkg/mod              # Module download cache
-          ~/.cache/go-build         # Build cache (Linux)
-          ~/Library/Caches/go-build # Build cache (Mac)
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
     - name: Checkout code
       uses: actions/checkout@v4
     - name: Test


### PR DESCRIPTION
Removed the 'Cache-Go' step from .github/workflows/goreleaser.yml, .github/workflows/golangci-lint.yml, and .github/workflows/test.yml as it is no longer necessary.

---
*PR created automatically by Jules for task [12839895922009811925](https://jules.google.com/task/12839895922009811925) started by @arran4*