### PR TITLE
Fix RCS date parsing for 2-digit years

### DIFF
--- a/date.go
+++ b/date.go
@@ -125,6 +125,9 @@ var dateLayouts = []dateLayout{
 	// date(1) variations
 	{"Fri Jan 02 15:04:05 MST 2006", FieldYear | FieldMonth | FieldDay | FieldHour | FieldMinute | FieldSecond | FieldZone},
 	{"Fri Jan 2 15:04:05 MST 2006", FieldYear | FieldMonth | FieldDay | FieldHour | FieldMinute | FieldSecond | FieldZone},
+
+	{"2006.01.02.15.04.05", FieldYear | FieldMonth | FieldDay | FieldHour | FieldMinute | FieldSecond},
+	{"06.01.02.15.04.05", FieldYear | FieldMonth | FieldDay | FieldHour | FieldMinute | FieldSecond},
 }
 
 func applyDefaults(t time.Time, now time.Time, fields int, targetZone *time.Location) time.Time {

--- a/parser.go
+++ b/parser.go
@@ -663,7 +663,7 @@ func ParseLockLine(s *Scanner) (*Lock, error) {
 func ParseRevisionHeaderDateLine(s *Scanner, haveHead bool, rh *RevisionHead) error {
 	if dateStr, err := ParseProperty(s, haveHead, "date", false); err != nil {
 		return err
-	} else if date, err := time.Parse(DateFormat, dateStr); err != nil {
+	} else if date, err := ParseDate(dateStr, time.Time{}, nil); err != nil {
 		return err
 	} else {
 		rh.Date = date

--- a/parser_date_compat_test.go
+++ b/parser_date_compat_test.go
@@ -1,0 +1,46 @@
+package rcs
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseRevisionHeaderDateLine_Compat(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		expectedTime time.Time
+	}{
+		{
+			name:         "2-digit year (1997)",
+			input:        "date\t97.04.06.08.41.11;\tauthor arran;\tstate Exp;\n",
+			expectedTime: time.Date(1997, 4, 6, 8, 41, 11, 0, time.UTC),
+		},
+		{
+			name:         "4-digit year (1997)",
+			input:        "date\t1997.04.06.08.41.11;\tauthor arran;\tstate Exp;\n",
+			expectedTime: time.Date(1997, 4, 6, 8, 41, 11, 0, time.UTC),
+		},
+		{
+			name:         "2-digit year (2020) - assuming 00-68 maps to 2000-2068",
+			input:        "date\t20.01.01.00.00.00;\tauthor arran;\tstate Exp;\n",
+			expectedTime: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewScanner(strings.NewReader(tt.input))
+			rh := &RevisionHead{}
+			err := ParseRevisionHeaderDateLine(s, false, rh)
+			if err != nil {
+				t.Errorf("ParseRevisionHeaderDateLine failed: %v", err)
+				return
+			}
+			if !rh.Date.Equal(tt.expectedTime) {
+				t.Errorf("Expected time %v, got %v", tt.expectedTime, rh.Date)
+			}
+		})
+	}
+}

--- a/parser_extensive_test.go
+++ b/parser_extensive_test.go
@@ -124,7 +124,7 @@ func TestParseRevisionHeaderDateLine_Errors(t *testing.T) {
 		{
 			name:    "Invalid date format",
 			input:   "date\tbad-date;",
-			wantErr: "parsing time",
+			wantErr: "unable to parse date",
 		},
 		{
 			name:    "Missing author",
@@ -173,7 +173,7 @@ func TestParseRevisionHeader_Errors(t *testing.T) {
 		{
 			name:    "Bad date",
 			input:   "1.1\ndate bad;",
-			wantErr: "token \"date\": parsing time",
+			wantErr: "token \"date\": unable to parse date",
 		},
 		{
 			name:    "Bad next",


### PR DESCRIPTION
This PR fixes an issue where RCS files with 2-digit years in revision dates (e.g., `97.04.06.08.41.11`) failed to parse. 

Changes:
1.  Modified `date.go` to include the specific dot-separated date format used in revision headers, including a 2-digit year variant.
2.  Modified `parser.go`'s `ParseRevisionHeaderDateLine` to use `rcs.ParseDate` instead of `time.Parse(DateFormat, ...)`. This allows the parser to try multiple date formats defined in `date.go`.
3.  Added `parser_date_compat_test.go` to verify that both 1997 (2-digit `97`) and 2020 (2-digit `20`) as well as 4-digit years parse correctly.
4.  Updated existing error checks in `parser_extensive_test.go` because `ParseDate` returns a different error message format ("unable to parse date") compared to `time.Parse` ("parsing time").

This ensures compatibility with older RCS files while maintaining support for newer ones.

---
*PR created automatically by Jules for task [2500282221346409701](https://jules.google.com/task/2500282221346409701) started by @arran4*