### PR TITLE
Format symbols in multi-line block in File.String()

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -109,16 +109,14 @@ func (f *File) String() string {
 	}
 	if f.Symbols {
 		if len(f.SymbolMap) > 0 {
-			sb.WriteString("symbols ")
+			sb.WriteString("symbols")
 			keys := make([]string, 0, len(f.SymbolMap))
 			for k := range f.SymbolMap {
 				keys = append(keys, k)
 			}
 			sort.Strings(keys)
-			for i, k := range keys {
-				if i > 0 {
-					sb.WriteString(" ")
-				}
+			for _, k := range keys {
+				sb.WriteString("\n\t")
 				sb.WriteString(fmt.Sprintf("%s:%s", k, f.SymbolMap[k]))
 			}
 			sb.WriteString(";\n")

--- a/parser_test.go
+++ b/parser_test.go
@@ -19,7 +19,9 @@ var (
 	accessSymbols = []byte(
 		"head\t1.1;\n" +
 			"access john jane;\n" +
-			"symbols rel:1.1 tag:1.1.0.2;\n" +
+			"symbols\n" +
+			"\trel:1.1\n" +
+			"\ttag:1.1.0.2;\n" +
 			"locks\n" +
 			"\tjohn:1.1;\n" +
 			"comment\t@# @;\n" +


### PR DESCRIPTION
Updated `File.String()` to format `symbols` block as a multi-line list. Updated tests to reflect this change.

---
*PR created automatically by Jules for task [10133781338886210451](https://jules.google.com/task/10133781338886210451) started by @arran4*