### PR TITLE
Refactor parser errors to use global variables

### DIFF
--- a/date.go
+++ b/date.go
@@ -61,7 +61,7 @@ func ParseDate(input string, now time.Time, defaultZone *time.Location) (time.Ti
 		}
 	}
 
-	return time.Time{}, fmt.Errorf("unable to parse date: %s", input)
+	return time.Time{}, fmt.Errorf("%w: %s", ErrDateParse, input)
 }
 
 const (

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,10 @@
+package rcs
+
+import "errors"
+
+var (
+	ErrEmptyId       = errors.New("empty id")
+	ErrRevisionEmpty = errors.New("revision empty")
+	ErrDateParse     = errors.New("unable to parse date")
+	ErrUnknownToken  = errors.New("unknown token")
+)

--- a/parser.go
+++ b/parser.go
@@ -345,7 +345,7 @@ func ParseHeader(s *Scanner, f *File) error {
 		case "\n\n", "\r\n\r\n":
 			return nil
 		default:
-			return fmt.Errorf("unknown token: %s", nt)
+			return fmt.Errorf("%w: %s", ErrUnknownToken, nt)
 		}
 	}
 }
@@ -425,7 +425,7 @@ func ParseRevisionHeader(s *Scanner) (*RevisionHead, bool, bool, error) {
 		case "\n", "\r\n":
 			continue
 		default:
-			return nil, false, false, fmt.Errorf("unknown token: %s", nt)
+			return nil, false, false, fmt.Errorf("%w: %s", ErrUnknownToken, nt)
 		}
 	}
 }
@@ -456,7 +456,7 @@ func ParseRevisionContent(s *Scanner) (*RevisionContent, bool, error) {
 	}
 	rh.Revision = s.Text()
 	if rh.Revision == "" {
-		return nil, false, fmt.Errorf("revision empty")
+		return nil, false, ErrRevisionEmpty
 	}
 	if err := ScanNewLine(s, false); err != nil {
 		return nil, false, err
@@ -487,7 +487,7 @@ func ParseRevisionContent(s *Scanner) (*RevisionContent, bool, error) {
 		case "\n", "\r\n":
 			return rh, false, nil
 		default:
-			return nil, false, fmt.Errorf("unknown token: %s", nt)
+			return nil, false, fmt.Errorf("%w: %s", ErrUnknownToken, nt)
 		}
 	}
 }
@@ -685,7 +685,7 @@ func ParseLockBody(s *Scanner, user string) (*Lock, error) {
 	}
 	l.Revision = s.Text()
 	if l.Revision == "" {
-		return nil, fmt.Errorf("revision empty")
+		return nil, ErrRevisionEmpty
 	}
 	if err := ScanFieldTerminator(s); err != nil {
 		return nil, err
@@ -706,7 +706,7 @@ func ParseLockBody(s *Scanner, user string) (*Lock, error) {
 			}
 		case " ":
 		default:
-			return nil, fmt.Errorf("unknown token: %s", nt)
+			return nil, fmt.Errorf("%w: %s", ErrUnknownToken, nt)
 		}
 	}
 }
@@ -743,7 +743,7 @@ func ParseRevisionHeaderDateLine(s *Scanner, haveHead bool, rh *RevisionHead) er
 				rh.State = s
 			}
 		default:
-			return fmt.Errorf("unknown token: %s", nt)
+			return fmt.Errorf("%w: %s", ErrUnknownToken, nt)
 		}
 	}
 	if err := ScanNewLine(s, false); err != nil {
@@ -984,7 +984,7 @@ func ScanLockIdOrStrings(s *Scanner, strs ...string) (id string, match string, e
 		for i, b := range data {
 			if b == ':' {
 				if i == 0 {
-					return 0, nil, fmt.Errorf("empty id")
+					return 0, nil, ErrEmptyId
 				}
 				return i, data[:i], nil
 			}


### PR DESCRIPTION
This change introduces global error variables for common parsing errors in the RCS library, allowing users to check for specific error conditions using `errors.Is`. The errors `ErrEmptyId`, `ErrRevisionEmpty`, `ErrDateParse`, and `ErrUnknownToken` are defined in `errors.go`. This refactoring improves the library's usability and maintainability without changing the logic or the error message output.

---
*PR created automatically by Jules for task [13316030513463750403](https://jules.google.com/task/13316030513463750403) started by @arran4*