### PR TITLE
Add support for owner, group, permissions, and hardlinks fields in revision block

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -31,6 +31,10 @@ type RevisionHead struct {
 	Branches     []string
 	NextRevision string
 	CommitID     string
+	Owner        string `json:",omitempty"`
+	Group        string `json:",omitempty"`
+	Permissions  string `json:",omitempty"`
+	Hardlinks    string `json:",omitempty"`
 }
 
 func (h *RevisionHead) String() string {
@@ -49,6 +53,18 @@ func (h *RevisionHead) String() string {
 	sb.WriteString(fmt.Sprintf("next\t%s;\n", h.NextRevision))
 	if h.CommitID != "" {
 		sb.WriteString(fmt.Sprintf("commitid\t%s;\n", h.CommitID))
+	}
+	if h.Owner != "" {
+		sb.WriteString(fmt.Sprintf("owner\t%s;\n", h.Owner))
+	}
+	if h.Group != "" {
+		sb.WriteString(fmt.Sprintf("group\t%s;\n", h.Group))
+	}
+	if h.Permissions != "" {
+		sb.WriteString(fmt.Sprintf("permissions\t%s;\n", h.Permissions))
+	}
+	if h.Hardlinks != "" {
+		sb.WriteString(fmt.Sprintf("hardlinks\t%s;\n", AtQuote(h.Hardlinks)))
 	}
 	return sb.String()
 }
@@ -398,7 +414,7 @@ func ParseRevisionHeader(s *Scanner) (*RevisionHead, bool, bool, error) {
 		return nil, false, true, nil
 	}
 	for {
-		if err := ScanStrings(s, "branches", "date", "next", "commitid", "\n\n", "\r\n\r\n", "\n", "\r\n"); err != nil {
+		if err := ScanStrings(s, "branches", "date", "next", "commitid", "owner", "group", "permissions", "hardlinks", "\n\n", "\r\n\r\n", "\n", "\r\n"); err != nil {
 			return nil, false, false, fmt.Errorf("finding revision header field: %w", err)
 		}
 		nt := s.Text()
@@ -422,6 +438,30 @@ func ParseRevisionHeader(s *Scanner) (*RevisionHead, bool, bool, error) {
 				return nil, false, false, fmt.Errorf("token %#v: %w", nt, err)
 			} else {
 				rh.CommitID = c
+			}
+		case "owner":
+			if o, err := ParseProperty(s, true, "owner", true); err != nil {
+				return nil, false, false, fmt.Errorf("token %#v: %w", nt, err)
+			} else {
+				rh.Owner = o
+			}
+		case "group":
+			if g, err := ParseProperty(s, true, "group", true); err != nil {
+				return nil, false, false, fmt.Errorf("token %#v: %w", nt, err)
+			} else {
+				rh.Group = g
+			}
+		case "permissions":
+			if p, err := ParseProperty(s, true, "permissions", true); err != nil {
+				return nil, false, false, fmt.Errorf("token %#v: %w", nt, err)
+			} else {
+				rh.Permissions = p
+			}
+		case "hardlinks":
+			if h, err := ParseHeaderComment(s, true); err != nil {
+				return nil, false, false, fmt.Errorf("token %#v: %w", nt, err)
+			} else {
+				rh.Hardlinks = h
 			}
 		case "\n\n", "\r\n\r\n":
 			return rh, true, false, nil

--- a/parser_test.go
+++ b/parser_test.go
@@ -1367,3 +1367,51 @@ func TestParseLockBody(t *testing.T) {
 		})
 	}
 }
+
+func TestParseRevisionHeaderWithExtraFields(t *testing.T) {
+	input := "1.2\n" +
+		"date\t99.01.12.14.05.31;\tauthor lhecking;\tstate dead;\n" +
+		"branches;\n" +
+		"next\t1.1;\n" +
+		"owner\t640;\n" +
+		"group\t15;\n" +
+		"permissions\t644;\n" +
+		"hardlinks\t@stringize.m4@;\n" +
+		"\n\n"
+
+	s := NewScanner(strings.NewReader(input))
+	rh, _, _, err := ParseRevisionHeader(s)
+	if err != nil {
+		t.Fatalf("ParseRevisionHeader returned error: %v", err)
+	}
+
+	if rh.Revision != "1.2" {
+		t.Errorf("Revision = %q, want %q", rh.Revision, "1.2")
+	}
+	if rh.Owner != "640" {
+		t.Errorf("Owner = %q, want %q", rh.Owner, "640")
+	}
+	if rh.Group != "15" {
+		t.Errorf("Group = %q, want %q", rh.Group, "15")
+	}
+	if rh.Permissions != "644" {
+		t.Errorf("Permissions = %q, want %q", rh.Permissions, "644")
+	}
+	if rh.Hardlinks != "stringize.m4" {
+		t.Errorf("Hardlinks = %q, want %q", rh.Hardlinks, "stringize.m4")
+	}
+
+	// Verify String() output
+	expectedOutput := "1.2\n" +
+		"date\t1999.01.12.14.05.31;\tauthor lhecking;\tstate dead;\n" +
+		"branches;\n" +
+		"next\t1.1;\n" +
+		"owner\t640;\n" +
+		"group\t15;\n" +
+		"permissions\t644;\n" +
+		"hardlinks\t@stringize.m4@;\n"
+
+	if diff := cmp.Diff(rh.String(), expectedOutput); diff != "" {
+		t.Errorf("String() mismatch (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
Add support for `owner`, `group`, `permissions`, and `hardlinks` fields in the RCS revision header.
- Updated `RevisionHead` struct in `parser.go`.
- Updated `ParseRevisionHeader` to parse these fields.
- Updated `RevisionHead.String()` to serialize these fields.
- Added test case in `parser_test.go`.

---
*PR created automatically by Jules for task [17830904147290625083](https://jules.google.com/task/17830904147290625083) started by @arran4*