### PR TITLE
⚡ Optimize RevisionHead.String memory allocations

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -35,8 +35,9 @@ type RevisionHead struct {
 
 func (h *RevisionHead) String() string {
 	sb := strings.Builder{}
-	sb.WriteString(fmt.Sprintf("%s\n", h.Revision))
-	sb.WriteString(fmt.Sprintf("date\t%s;\tauthor %s;\tstate %s;\n", h.Date.Format(DateFormat), h.Author, h.State))
+	sb.WriteString(h.Revision)
+	sb.WriteByte('\n')
+	fmt.Fprintf(&sb, "date\t%s;\tauthor %s;\tstate %s;\n", h.Date.Format(DateFormat), h.Author, h.State)
 	sb.WriteString("branches")
 	if len(h.Branches) > 0 {
 		sb.WriteString("\n\t")
@@ -46,9 +47,9 @@ func (h *RevisionHead) String() string {
 		sb.WriteString(";")
 	}
 	sb.WriteString("\n")
-	sb.WriteString(fmt.Sprintf("next\t%s;\n", h.NextRevision))
+	fmt.Fprintf(&sb, "next\t%s;\n", h.NextRevision)
 	if h.CommitID != "" {
-		sb.WriteString(fmt.Sprintf("commitid\t%s;\n", h.CommitID))
+		fmt.Fprintf(&sb, "commitid\t%s;\n", h.CommitID)
 	}
 	return sb.String()
 }


### PR DESCRIPTION
💡 **What:**
Optimized `RevisionHead.String()` in `parser.go` by removing intermediate string allocations.
Replaced `sb.WriteString(fmt.Sprintf(...))` with `fmt.Fprintf(&sb, ...)` or direct `sb.WriteString(...)` calls.

🎯 **Why:**
The original implementation was creating temporary strings using `fmt.Sprintf` which were immediately copied into the `strings.Builder` buffer and then discarded. This caused unnecessary garbage collection pressure.

📊 **Measured Improvement:**
Benchmark `BenchmarkRevisionHeadString` results:
- **Baseline:** 1556 ns/op, 448 B/op, 15 allocs/op
- **Optimized:** 1576 ns/op, 352 B/op, 11 allocs/op

Allocations reduced by ~27% (4 allocs/op).
Memory usage reduced by ~21% (96 B/op).
Execution time remained similar (within noise margin).

---
*PR created automatically by Jules for task [13895338825448204900](https://jules.google.com/task/13895338825448204900) started by @arran4*