### PR TITLE
Refactor regex compilation in date.go

### DIFF
--- a/date.go
+++ b/date.go
@@ -194,10 +194,14 @@ func applyDefaults(t time.Time, now time.Time, fields int, targetZone *time.Loca
 	return time.Date(year, month, day, hour, min, sec, 0, finalZone)
 }
 
+var (
+	reYearDOY     = regexp.MustCompile(`^(\d{4})-(\d{1,3})$`)
+	reYearWeekDow = regexp.MustCompile(`^(\d{4})-w(\d{1,2})-(\d)$`)
+)
+
 // parseYearDOY handles format YEAR-DOY (e.g., 2018-110)
 func parseYearDOY(input string, loc *time.Location) (time.Time, bool) {
-	re := regexp.MustCompile(`^(\d{4})-(\d{1,3})$`)
-	matches := re.FindStringSubmatch(input)
+	matches := reYearDOY.FindStringSubmatch(input)
 	if matches == nil {
 		return time.Time{}, false
 	}
@@ -214,8 +218,7 @@ func parseYearDOY(input string, loc *time.Location) (time.Time, bool) {
 
 // parseYearWeekDow handles format YEAR-wWEEK-DOW (e.g., 2018-w16-5)
 func parseYearWeekDow(input string, loc *time.Location) (time.Time, bool) {
-	re := regexp.MustCompile(`^(\d{4})-w(\d{1,2})-(\d)$`)
-	matches := re.FindStringSubmatch(input)
+	matches := reYearWeekDow.FindStringSubmatch(input)
 	if matches == nil {
 		return time.Time{}, false
 	}


### PR DESCRIPTION
- Defined `reYearDOY` and `reYearWeekDow` as package-level variables in `date.go`.
- Updated `parseYearDOY` to use `reYearDOY`.
- Updated `parseYearWeekDow` to use `reYearWeekDow`.
- Verified changes with existing tests in `date_test.go`.

---
*PR created automatically by Jules for task [14878801091590599458](https://jules.google.com/task/14878801091590599458) started by @arran4*