### PR TITLE
Fix unbounded memory allocation in scanner

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"math"
 )
 
 type Scanner struct {
@@ -73,7 +72,7 @@ func NewScanner(r io.Reader, opts ...ScannerOpt) *Scanner {
 		sf: bufio.ScanLines,
 	}
 	scanner.Scanner.Split(scanner.scannerWrapper)
-	scanner.Buffer(nil, math.MaxInt/2)
+	scanner.Buffer(nil, 64*1024*1024)
 	for _, opt := range opts {
 		opt.ScannerOpt(scanner)
 	}

--- a/scanner_limit_test.go
+++ b/scanner_limit_test.go
@@ -1,0 +1,58 @@
+package rcs
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScannerLargeTokenDefault(t *testing.T) {
+	// 5MB token - checks if we can scan reasonably large tokens (larger than default 64KB bufio limit)
+	size := 5 * 1024 * 1024
+	largeToken := strings.Repeat("a", size)
+	input := "@" + largeToken + "@"
+
+	s := NewScanner(strings.NewReader(input))
+	val, err := ParseAtQuotedString(s)
+	if err != nil {
+		t.Fatalf("Failed to scan %d MB token with default scanner: %v", size/1024/1024, err)
+	}
+	if len(val) != size {
+		t.Errorf("Expected token length %d, got %d", size, len(val))
+	}
+}
+
+func TestScannerEnforceLimit(t *testing.T) {
+	// 5MB token
+	size := 5 * 1024 * 1024
+	largeToken := strings.Repeat("a", size)
+	input := "@" + largeToken + "@"
+
+	// Set limit to 1MB. This should fail because token is 5MB.
+	s := NewScanner(strings.NewReader(input), MaxBuffer(1024*1024))
+	_, err := ParseAtQuotedString(s)
+	if err == nil {
+		t.Fatalf("Expected error when scanning token larger than limit, got nil")
+	}
+	if !strings.Contains(err.Error(), "token too long") {
+		t.Logf("Got error: %v", err)
+	}
+}
+
+func TestScannerDefaultLimitEnforced(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping large allocation test in short mode")
+	}
+	// 65MB token, slightly larger than 64MB default limit
+	size := 65 * 1024 * 1024
+	largeToken := strings.Repeat("a", size)
+	input := "@" + largeToken + "@"
+
+	s := NewScanner(strings.NewReader(input))
+	_, err := ParseAtQuotedString(s)
+	if err == nil {
+		t.Fatalf("Expected error when scanning token larger than default limit (64MB), got nil. Buffer limit is not enforced.")
+	}
+	if !strings.Contains(err.Error(), "token too long") {
+		t.Logf("Got error: %v", err)
+	}
+}


### PR DESCRIPTION
🎯 **What:** Fixed an unbounded memory allocation vulnerability in `scanner.go`. The scanner's buffer limit was previously set to `math.MaxInt/2`, which could allow malicious inputs to cause an Out-Of-Memory (OOM) crash.

⚠️ **Risk:** If left unfixed, an attacker could supply a crafted RCS file with an extremely large token (e.g., a huge description or log message), causing the application to attempt to allocate a massive amount of memory and crash.

🛡️ **Solution:**
- Changed the default buffer limit in `NewScanner` from `math.MaxInt/2` to 64MB (`64 * 1024 * 1024`).
- Removed the unused `math` import.
- Added `scanner_limit_test.go` with regression tests:
    - `TestScannerLargeTokenDefault`: Verifies that legitimate large tokens (5MB) are still processed correctly.
    - `TestScannerEnforceLimit`: Verifies that the `MaxBuffer` option can still be used to set a custom limit.
    - `TestScannerDefaultLimitEnforced`: Verifies that the new default 64MB limit is enforced (tokens > 64MB cause an error).

---
*PR created automatically by Jules for task [12045916864019322624](https://jules.google.com/task/12045916864019322624) started by @arran4*