### PR TITLE
Fix parsing of RCS expand header field to support unquoted words and colons

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -359,7 +359,7 @@ func ParseHeader(s *Scanner, f *File) error {
 				f.Comment = comment
 			}
 		case "expand":
-			if expand, err := ParseOptionalToken(s, ScanTokenStringOrId, WithPropertyName("expand"), WithConsumed(true), WithLine(true)); err != nil {
+			if expand, err := ParseOptionalToken(s, ScanTokenWord, WithPropertyName("expand"), WithConsumed(true), WithLine(true)); err != nil {
 				return fmt.Errorf("token %#v: %w", nt, err)
 			} else {
 				f.Expand = expand

--- a/token_scanner.go
+++ b/token_scanner.go
@@ -91,9 +91,12 @@ func ScanTokenString(s *Scanner) (string, error) {
 	return ParseAtQuotedString(s)
 }
 
-func ScanTokenStringOrId(s *Scanner) (string, error) {
+func ScanTokenWord(s *Scanner) (string, error) {
 	if err := ScanStrings(s, "@"); err == nil {
 		return ParseAtQuotedStringBody(s)
+	}
+	if err := ScanStrings(s, ":"); err == nil {
+		return ":", nil
 	}
 	return ScanTokenId(s)
 }

--- a/token_scanner_test.go
+++ b/token_scanner_test.go
@@ -161,3 +161,36 @@ func TestScanTokenIntString(t *testing.T) {
 		})
 	}
 }
+
+func TestScanTokenWord(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{"String", "@foo@", "foo", false},
+		{"Id", "foo;", "foo", false},
+		{"Id with digits", "foo123;", "foo123", false},
+		{"Id with dot", "foo.bar;", "foo.bar", false},
+		{"Empty string", "@@", "", false},
+		{"Missing start quote ID", "foo@", "foo", false},
+		{"Missing end quote String", "@foo", "", true},
+		{"Expand Unquoted", "kv;", "kv", false},
+		{"Colon", ":", ":", false},
+		{"Colon with suffix", ":;", ":", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewScanner(strings.NewReader(tt.input))
+			got, err := ScanTokenWord(s)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ScanTokenWord() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ScanTokenWord() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR fixes an issue where the `expand` header field was not correctly parsed when the value was unquoted or a colon, as allowed by the RCS grammar.

Changes:
- Renamed `ScanTokenStringOrId` to `ScanTokenWord` in `token_scanner.go` and `parser.go`.
- Updated `ScanTokenWord` to explicitly support the colon (`:`) token, in addition to `@`-quoted strings and identifiers (including numbers).
- Updated `parser_test.go`:
    - Fixed a bug where `accessSymbols` was undefined (replaced with `accessSymbolsv`).
    - Updated `TestParseHeaderExpandIntegrity` to expect success for unquoted `expand` values.
    - Refactored `TestParseFile` to use a `checkFile` callback, allowing different assertions for different input files (fixing a regression introduced by the new test case).
- Added `TestScanTokenWord` to `token_scanner_test.go` to verify correct scanning of strings, IDs, numbers, and colons.

This ensures robust parsing of the `expand` field across various valid RCS formats.

---
*PR created automatically by Jules for task [2094040469043301902](https://jules.google.com/task/2094040469043301902) started by @arran4*