### PR TITLE
Refactor Format and Validate to accept io.Reader and io.Writer

### DIFF
--- a/cmd/gorcs/format.go
+++ b/cmd/gorcs/format.go
@@ -138,7 +138,7 @@ func (c *Format) Execute(args []string) error {
 		c.files = varArgs
 	}
 
-	cli.Format(c.output, c.force, c.overwrite, c.stdout, c.keepTruncatedYears, c.files...)
+	cli.Format(os.Stdin, os.Stdout, c.output, c.force, c.overwrite, c.stdout, c.keepTruncatedYears, c.files...)
 
 	return nil
 }

--- a/cmd/gorcs/validate.go
+++ b/cmd/gorcs/validate.go
@@ -127,7 +127,7 @@ func (c *Validate) Execute(args []string) error {
 		c.files = varArgs
 	}
 
-	cli.Validate(c.output, c.force, c.overwrite, c.stdout, c.files...)
+	cli.Validate(os.Stdin, os.Stdout, c.output, c.force, c.overwrite, c.stdout, c.files...)
 
 	return nil
 }

--- a/internal/cli/format.go
+++ b/internal/cli/format.go
@@ -18,11 +18,7 @@ import (
 //			stdout: -s --stdout Force output to stdout
 //	    keep-truncated-years: --keep-truncated-years Keep truncated years (do not expand to 4 digits)
 //			files: ... List of files to process, or - for stdin
-func Format(output string, force, overwrite, stdoutFlag, keepTruncatedYears bool, files ...string) {
-	runFormat(os.Stdin, os.Stdout, output, force, overwrite, stdoutFlag, keepTruncatedYears, files...)
-}
-
-func runFormat(stdin io.Reader, stdout io.Writer, output string, force, overwrite, stdoutFlag, keepTruncatedYears bool, files ...string) {
+func Format(stdin io.Reader, stdout io.Writer, output string, force, overwrite, stdoutFlag, keepTruncatedYears bool, files ...string) {
 	if output != "" && len(files) > 1 {
 		log.Panicf("Cannot specify output file with multiple input files")
 	}

--- a/internal/cli/format_test.go
+++ b/internal/cli/format_test.go
@@ -16,8 +16,7 @@ func TestFormat_KeepTruncatedYears(t *testing.T) {
 	var buf bytes.Buffer
 
 	// Run Format with keepTruncatedYears=true, stdout=true
-	// Signature: func runFormat(stdin io.Reader, stdout io.Writer, output string, force, overwrite, stdout, keepTruncatedYears bool, files ...string)
-	runFormat(r, &buf, "", false, false, true, true, "-")
+	Format(r, &buf, "", false, false, true, true, "-")
 
 	output := buf.String()
 
@@ -31,7 +30,7 @@ func TestFormat_KeepTruncatedYears(t *testing.T) {
 	buf.Reset()
 
 	// Run Format with keepTruncatedYears=false (default), stdout=true
-	runFormat(r, &buf, "", false, false, true, false, "-")
+	Format(r, &buf, "", false, false, true, false, "-")
 
 	output = buf.String()
 

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -1,6 +1,8 @@
 package cli
 
-import "os"
+import (
+	"io"
+)
 
 // Validate is a subcommand `gorcs validate`
 //
@@ -11,8 +13,8 @@ import "os"
 //	overwrite: -w --overwrite Overwrite input file
 //	stdout: -s --stdout Force output to stdout
 //	files: ... List of files to process, or - for stdin
-func Validate(output string, force, overwrite, stdoutFlag bool, files ...string) {
+func Validate(stdin io.Reader, stdout io.Writer, output string, force, overwrite, stdoutFlag bool, files ...string) {
 	// Validate is currently functionally identical to Format (parse and re-serialize).
 	// If validation rules diverge in future, logic can be separated here.
-	runFormat(os.Stdin, os.Stdout, output, force, overwrite, stdoutFlag, false, files...)
+	Format(stdin, stdout, output, force, overwrite, stdoutFlag, false, files...)
 }


### PR DESCRIPTION
Refactored `Format` and `Validate` in `internal/cli` to accept `io.Reader` and `io.Writer`, removing the need for `runFormat` and enabling direct testing of the public API without global state. Updated CLI commands to inject `os.Stdin` and `os.Stdout`.

---
*PR created automatically by Jules for task [9812038405247759121](https://jules.google.com/task/9812038405247759121) started by @arran4*