### PR TITLE
⚡ Optimize AtQuote with streaming WriteAtQuote

### DIFF
--- a/parser_benchmark_test.go
+++ b/parser_benchmark_test.go
@@ -26,7 +26,7 @@ func BenchmarkWriteAtQuote_Stream(b *testing.B) {
 	var sb strings.Builder
 	for i := 0; i < b.N; i++ {
 		sb.Reset()
-		WriteAtQuote(&sb, s)
+		_, _ = WriteAtQuote(&sb, s)
 	}
 }
 
@@ -35,7 +35,7 @@ func BenchmarkWriteAtQuote_Stream_Long(b *testing.B) {
 	var sb strings.Builder
 	for i := 0; i < b.N; i++ {
 		sb.Reset()
-		WriteAtQuote(&sb, s)
+		_, _ = WriteAtQuote(&sb, s)
 	}
 }
 
@@ -57,7 +57,7 @@ func BenchmarkStringer_Usage_WriteAtQuote(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		sb.Reset()
 		sb.WriteString("prefix")
-		WriteAtQuote(&sb, s)
+		_, _ = WriteAtQuote(&sb, s)
 		sb.WriteString("suffix")
 	}
 }


### PR DESCRIPTION
💡 **What:** Implemented `WriteAtQuote` in `parser.go` which streams escaped content directly to `*strings.Builder`, avoiding intermediate string allocations. Updated `RevisionHead.String()`, `RevisionContent.String()`, and `File.String()` to use this new helper.

🎯 **Why:** The previous `AtQuote` implementation allocated new strings for every call (using `strings.ReplaceAll` and concatenation), which was inefficient for large RCS files or frequent string generation.

📊 **Measured Improvement:**
Benchmark results show a significant performance improvement (~48% time reduction) for string generation simulating RCS file output.

Baseline (AtQuote):
BenchmarkStringer_Usage_AtQuote-4   	 2739480	       394.2 ns/op	     128 B/op	       4 allocs/op

Optimized (WriteAtQuote):
BenchmarkStringer_Usage_WriteAtQuote-4   	 5653852	       206.0 ns/op	     120 B/op	       4 allocs/op

---
*PR created automatically by Jules for task [681232180987481915](https://jules.google.com/task/681232180987481915) started by @arran4*