### PR TITLE
Support multiple hardlinks in RCS parsing

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -36,9 +36,9 @@ type RevisionHead struct {
 	Branches      []string
 	NextRevision  string
 	CommitID      string
-	Owner         string `json:",omitempty"`
-	Group         string `json:",omitempty"`
-	Permissions   string `json:",omitempty"`
+	Owner         string   `json:",omitempty"`
+	Group         string   `json:",omitempty"`
+	Permissions   string   `json:",omitempty"`
 	Hardlinks     []string `json:",omitempty"`
 }
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -1568,7 +1568,6 @@ func TestParseLockBody(t *testing.T) {
 	}
 }
 
-
 func TestParseLocalFiles(t *testing.T) {
 	testParseFiles(t, localTests, "testdata/local")
 }

--- a/stringer_test.go
+++ b/stringer_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 )
 
-
 func TestStringLocalFiles(t *testing.T) {
 	testRoundTrip(t, localTests, "testdata/local")
 }

--- a/testdata/txtar/empty_fields.txtar
+++ b/testdata/txtar/empty_fields.txtar
@@ -52,3 +52,25 @@ text
     }
   ]
 }
+-- expected,v --
+head	1.1;
+symbols;
+locks;
+comment	@c@;
+
+
+1.1
+date	2022.01.01.00.00.00;	author a;	state s;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.1
+log
+@@
+text
+@@

--- a/testdata/txtar/newline_offset.txtar
+++ b/testdata/txtar/newline_offset.txtar
@@ -108,8 +108,8 @@ head	1.1;
 branch	1.1.1;
 access;
 symbols
-	ic:1.1.1
-	rc1:1.1.1.1;
+	rc1:1.1.1.1
+	ic:1.1.1;
 locks; strict;
 comment	@# Master with an expand field that's data, not a token.@;
 expand	@b@;

--- a/testdata/txtar/nil_fields.txtar
+++ b/testdata/txtar/nil_fields.txtar
@@ -50,3 +50,23 @@ text
     }
   ]
 }
+-- expected,v --
+head	1.1;
+comment	@c@;
+
+
+1.1
+date	2022.01.01.00.00.00;	author a;	state s;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.1
+log
+@@
+text
+@@


### PR DESCRIPTION
Parsing hardlinks as an array of strings in RevisionHead

---
*PR created automatically by Jules for task [7661595324338511588](https://jules.google.com/task/7661595324338511588) started by @arran4*