### PR TITLE
Standardize CLI flags to use -f for overwrite

### DIFF
--- a/cmd/gorcs/format.go
+++ b/cmd/gorcs/format.go
@@ -17,7 +17,6 @@ type Format struct {
 	Flags              *flag.FlagSet
 	output             string
 	force              bool
-	overwrite          bool
 	keepTruncatedYears bool
 	files              []string
 	SubCommands        map[string]Cmd
@@ -87,16 +86,6 @@ func (c *Format) Execute(args []string) error {
 				} else {
 					c.force = true
 				}
-			case "overwrite", "w":
-				if hasValue {
-					b, err := strconv.ParseBool(value)
-					if err != nil {
-						return fmt.Errorf("invalid boolean value for flag %s: %s", name, value)
-					}
-					c.overwrite = b
-				} else {
-					c.overwrite = true
-				}
 			case "keep-truncated-years":
 				if hasValue {
 					b, err := strconv.ParseBool(value)
@@ -127,7 +116,7 @@ func (c *Format) Execute(args []string) error {
 		c.files = varArgs
 	}
 
-	cli.Format(c.output, c.force, c.overwrite, c.keepTruncatedYears, c.files...)
+	cli.Format(c.output, c.force, c.keepTruncatedYears, c.files...)
 
 	return nil
 }
@@ -145,9 +134,6 @@ func (c *RootCmd) NewFormat() *Format {
 
 	set.BoolVar(&v.force, "f", false, "Force overwrite output")
 	set.BoolVar(&v.force, "force", false, "Force overwrite output")
-
-	set.BoolVar(&v.overwrite, "w", false, "Overwrite input file")
-	set.BoolVar(&v.overwrite, "overwrite", false, "Overwrite input file")
 
 	set.BoolVar(&v.keepTruncatedYears, "keep-truncated-years", false, "Keep truncated years (do not expand to 4 digits)")
 

--- a/cmd/gorcs/validate.go
+++ b/cmd/gorcs/validate.go
@@ -17,7 +17,6 @@ type Validate struct {
 	Flags       *flag.FlagSet
 	output      string
 	force       bool
-	overwrite   bool
 	files       []string
 	SubCommands map[string]Cmd
 }
@@ -86,16 +85,6 @@ func (c *Validate) Execute(args []string) error {
 				} else {
 					c.force = true
 				}
-			case "overwrite", "w":
-				if hasValue {
-					b, err := strconv.ParseBool(value)
-					if err != nil {
-						return fmt.Errorf("invalid boolean value for flag %s: %s", name, value)
-					}
-					c.overwrite = b
-				} else {
-					c.overwrite = true
-				}
 			case "help", "h":
 				c.Usage()
 				return nil
@@ -116,7 +105,7 @@ func (c *Validate) Execute(args []string) error {
 		c.files = varArgs
 	}
 
-	cli.Validate(c.output, c.force, c.overwrite, c.files...)
+	cli.Validate(c.output, c.force, c.files...)
 
 	return nil
 }
@@ -134,9 +123,6 @@ func (c *RootCmd) NewValidate() *Validate {
 
 	set.BoolVar(&v.force, "f", false, "Force overwrite output")
 	set.BoolVar(&v.force, "force", false, "Force overwrite output")
-
-	set.BoolVar(&v.overwrite, "w", false, "Overwrite input file")
-	set.BoolVar(&v.overwrite, "overwrite", false, "Overwrite input file")
 
 	set.Usage = v.Usage
 

--- a/internal/cli/format.go
+++ b/internal/cli/format.go
@@ -14,19 +14,15 @@ import (
 //
 //			output: -o --output Output file path
 //			force: -f --force Force overwrite output
-//			overwrite: -w --overwrite Overwrite input file
 //	    keep-truncated-years: --keep-truncated-years Keep truncated years (do not expand to 4 digits)
 //			files: ... List of files to process, or - for stdin
-func Format(output string, force, overwrite, keepTruncatedYears bool, files ...string) {
-	runFormat(os.Stdin, os.Stdout, output, force, overwrite, keepTruncatedYears, files...)
+func Format(output string, force, keepTruncatedYears bool, files ...string) {
+	runFormat(os.Stdin, os.Stdout, output, force, keepTruncatedYears, files...)
 }
 
-func runFormat(stdin io.Reader, stdout io.Writer, output string, force, overwrite, keepTruncatedYears bool, files ...string) {
+func runFormat(stdin io.Reader, stdout io.Writer, output string, force, keepTruncatedYears bool, files ...string) {
 	if output != "" && output != "-" && len(files) > 1 {
 		log.Panicf("Cannot specify output file with multiple input files")
-	}
-	if overwrite && output != "" {
-		log.Panicf("Cannot specify both overwrite and output file")
 	}
 
 	for _, fn := range files {
@@ -58,7 +54,7 @@ func runFormat(stdin io.Reader, stdout io.Writer, output string, force, overwrit
 			}
 		}
 
-		if overwrite {
+		if output == "" && force {
 			if fn == "-" {
 				log.Panicf("Cannot overwrite stdin")
 			}

--- a/internal/cli/format_test.go
+++ b/internal/cli/format_test.go
@@ -16,8 +16,8 @@ func TestFormat_KeepTruncatedYears(t *testing.T) {
 	var buf bytes.Buffer
 
 	// Run Format with keepTruncatedYears=true, stdout=true
-	// Signature: func runFormat(stdin io.Reader, stdout io.Writer, output string, force, overwrite, keepTruncatedYears bool, files ...string)
-	runFormat(r, &buf, "-", false, false, true, "-")
+	// Signature: func runFormat(stdin io.Reader, stdout io.Writer, output string, force, keepTruncatedYears bool, files ...string)
+	runFormat(r, &buf, "-", false, true, "-")
 
 	output := buf.String()
 
@@ -31,7 +31,7 @@ func TestFormat_KeepTruncatedYears(t *testing.T) {
 	buf.Reset()
 
 	// Run Format with keepTruncatedYears=false (default), stdout=true
-	runFormat(r, &buf, "-", false, false, false, "-")
+	runFormat(r, &buf, "-", false, false, "-")
 
 	output = buf.String()
 

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -8,10 +8,9 @@ import "os"
 //
 //	output: -o --output Output file path
 //	force: -f --force Force overwrite output
-//	overwrite: -w --overwrite Overwrite input file
 //	files: ... List of files to process, or - for stdin
-func Validate(output string, force, overwrite bool, files ...string) {
+func Validate(output string, force bool, files ...string) {
 	// Validate is currently functionally identical to Format (parse and re-serialize).
 	// If validation rules diverge in future, logic can be separated here.
-	runFormat(os.Stdin, os.Stdout, output, force, overwrite, false, files...)
+	runFormat(os.Stdin, os.Stdout, output, force, false, files...)
 }


### PR DESCRIPTION
Standardize on -f/--force flag for overwriting input files in format and validate commands, removing -w/--overwrite flag.
This simplifies the CLI interface and aligns behavior across subcommands.
Modifies `cmd/gorcs/format.go`, `cmd/gorcs/validate.go`, `internal/cli/format.go`, `internal/cli/validate.go`, and `internal/cli/format_test.go`.


---
*PR created automatically by Jules for task [6540449972254809441](https://jules.google.com/task/6540449972254809441) started by @arran4*