### PR TITLE
Update go.mod to Go 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,8 @@
 module github.com/arran4/golang-rcs
 
-go 1.24.0
-
-toolchain go1.24.3
+go 1.22
 
 require (
 	github.com/google/go-cmp v0.6.0
-	golang.org/x/tools v0.42.0
+	golang.org/x/tools v0.22.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-golang.org/x/tools v0.42.0 h1:uNgphsn75Tdz5Ji2q36v/nsFSfR/9BRFvqhGBaJGd5k=
-golang.org/x/tools v0.42.0/go.mod h1:Ma6lCIwGZvHK6XtgbswSoWroEkhugApmsXyrUmBhfr0=
+golang.org/x/tools v0.22.0 h1:gqSGLZqv+AI9lIQzniJ0nZDRG5GBPsSi+DRNHWNz6yA=
+golang.org/x/tools v0.22.0/go.mod h1:aCwcsjqvq7Yqt6TNyX7QMU2enbQ/Gt0bo6krSeEri+c=


### PR DESCRIPTION
Updated `go.mod` to use Go 1.22 as requested. Also updated `golang.org/x/tools` dependency to `v0.22.0` which is compatible with Go 1.22, as the previous version `v0.42.0` required Go 1.24. Verified changes with `go mod tidy` and `go test ./...`.

---
*PR created automatically by Jules for task [5612750206419433411](https://jules.google.com/task/5612750206419433411) started by @arran4*