### PR TITLE
Add tests for ci -n and -N flags

### DIFF
--- a/testdata/txtar/operations/50-ci-n-flag.sh
+++ b/testdata/txtar/operations/50-ci-n-flag.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUT="50-ci-n-flag.txtar"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+
+cat > file.txt <<'EOF'
+This is a test for the -n flag.
+Assigning a symbolic name on initial checkin.
+EOF
+
+# Execute ci with -nTAG
+ci -q -i -u -m"initial checkin" -nTAG -wtester -d'2021-01-01 00:00:00Z' file.txt </dev/null
+
+cat > "$OLDPWD/$OUT" <<EOF
+-- description.txt --
+ci with -n flag (assign symbolic name)
+
+-- options.conf --
+{"args": ["-q","-i","-u","-m","initial checkin","-nTAG","-wtester","-d","2021-01-01 00:00:00Z","input.txt"] }
+
+-- input.txt --
+This is a test for the -n flag.
+Assigning a symbolic name on initial checkin.
+
+-- tests.txt --
+ci
+
+-- expected.txt,v --
+$(cat file.txt,v)
+EOF

--- a/testdata/txtar/operations/50-ci-n-flag.txtar
+++ b/testdata/txtar/operations/50-ci-n-flag.txtar
@@ -1,0 +1,40 @@
+-- description.txt --
+ci with -n flag (assign symbolic name)
+
+-- options.conf --
+{"args": ["-q","-i","-u","-m","initial checkin","-nTAG","-wtester","-d","2021-01-01 00:00:00Z","input.txt"] }
+
+-- input.txt --
+This is a test for the -n flag.
+Assigning a symbolic name on initial checkin.
+
+-- tests.txt --
+ci
+
+-- expected.txt,v --
+head	1.1;
+access;
+symbols
+	TAG:1.1;
+locks; strict;
+comment	@# @;
+
+
+1.1
+date	2021.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.1
+log
+@initial checkin
+@
+text
+@This is a test for the -n flag.
+Assigning a symbolic name on initial checkin.
+@

--- a/testdata/txtar/operations/51-ci-N-flag.sh
+++ b/testdata/txtar/operations/51-ci-N-flag.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUT="51-ci-N-flag.txtar"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+
+cat > file.txt <<'EOF'
+Initial content.
+EOF
+
+# Initial checkin with symbol TAG pointing to 1.1
+ci -q -i -u -m"r1" -nTAG -wtester -d'2021-01-01 00:00:00Z' file.txt </dev/null
+
+# Prepare input state (1.1 checked in, TAG=1.1)
+# Make file writable to modify it, simulating work
+rcs -q -U file.txt
+chmod u+w file.txt
+cp file.txt,v input.txt,v
+
+# Modify file for 1.2
+cat >> file.txt <<'EOF'
+Modified content.
+EOF
+cp file.txt input.txt
+
+# Execute ci with -NTAG (should move TAG to 1.2)
+ci -q -u -m"r2" -NTAG -wtester -d'2021-01-02 00:00:00Z' file.txt </dev/null
+
+cat > "$OLDPWD/$OUT" <<EOF
+-- description.txt --
+ci with -N flag (overwrite symbolic name)
+
+-- options.conf --
+{"args": ["-q","-u","-m","r2","-NTAG","-wtester","-d","2021-01-02 00:00:00Z","input.txt"] }
+
+-- input.txt --
+$(cat input.txt)
+
+-- input.txt,v --
+$(cat input.txt,v)
+
+-- tests.txt --
+ci
+
+-- expected.txt,v --
+$(cat file.txt,v)
+EOF

--- a/testdata/txtar/operations/51-ci-N-flag.txtar
+++ b/testdata/txtar/operations/51-ci-N-flag.txtar
@@ -1,0 +1,81 @@
+-- description.txt --
+ci with -N flag (overwrite symbolic name)
+
+-- options.conf --
+{"args": ["-q","-u","-m","r2","-NTAG","-wtester","-d","2021-01-02 00:00:00Z","input.txt"] }
+
+-- input.txt --
+Initial content.
+Modified content.
+
+-- input.txt,v --
+head	1.1;
+access;
+symbols
+	TAG:1.1;
+locks;
+comment	@# @;
+
+
+1.1
+date	2021.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.1
+log
+@r1
+@
+text
+@Initial content.
+@
+
+-- tests.txt --
+ci
+
+-- expected.txt,v --
+head	1.2;
+access;
+symbols
+	TAG:1.2;
+locks;
+comment	@# @;
+
+
+1.2
+date	2021.01.02.00.00.00;	author tester;	state Exp;
+branches;
+next	1.1;
+
+1.1
+date	2021.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.2
+log
+@r2
+@
+text
+@Initial content.
+Modified content.
+@
+
+
+1.1
+log
+@r1
+@
+text
+@d2 1
+@


### PR DESCRIPTION
Added two new test cases in testdata/txtar/operations covering the usage of -n (new symbol) and -N (overwrite symbol) flags with the ci command, along with their generator scripts.

---
*PR created automatically by Jules for task [7798688418470115568](https://jules.google.com/task/7798688418470115568) started by @arran4*