### PR TITLE
Add ci -f operations tests

### DIFF
--- a/testdata/txtar/operations/55-ci-force-rev-skip.sh
+++ b/testdata/txtar/operations/55-ci-force-rev-skip.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NAME="55-ci-force-rev-skip"
+OUT="$OUTDIR/$NAME.txtar"
+TMP_OUT="$OUTDIR/.$NAME.txtar.tmp.$$"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp" "$TMP_OUT"' EXIT
+cd "$tmp"
+
+# Create initial content
+printf "INITIAL\nCONTENT\n" > file.txt
+
+# setup: create 1.1
+ci -q -i -u -m"initial" -wtester -d'2020-01-01 00:00:00Z' file.txt </dev/null
+rcs -q -U file.txt
+
+# Prepare input state
+cp file.txt   input.txt
+cp file.txt,v input.txt,v
+
+# Modify file if needed
+# ensure file is writable as ci -u makes it read-only
+chmod +w file.txt
+printf 'NEW\nCONTENT\n' > file.txt
+
+# execution
+# We run the command to generate the expected output
+ci -q -u -f1.5 -m'forced-skip' -wtester -d'2020-01-02 00:00:00Z' file.txt </dev/null
+
+cat > "$TMP_OUT" <<EOF
+-- description.txt --
+ci -f1.5 forces revision 1.5 skipping intermediate revisions
+
+-- options.conf --
+{"args": ["-q", "-u", "-f1.5", "-m", "forced-skip", "-wtester", "-d", "2020-01-02 00:00:00Z", "input.txt"]}
+
+-- input.txt --
+$(cat input.txt)
+
+-- input.txt,v --
+$(cat input.txt,v)
+
+-- tests.txt --
+ci
+
+-- tests.md --
+ci
+
+-- expected.txt,v --
+$(cat file.txt,v)
+EOF
+
+mv -f "$TMP_OUT" "$OUT"

--- a/testdata/txtar/operations/55-ci-force-rev-skip.txtar
+++ b/testdata/txtar/operations/55-ci-force-rev-skip.txtar
@@ -1,0 +1,85 @@
+-- description.txt --
+ci -f1.5 forces revision 1.5 skipping intermediate revisions
+
+-- options.conf --
+{"args": ["-q", "-u", "-f1.5", "-m", "forced-skip", "-wtester", "-d", "2020-01-02 00:00:00Z", "input.txt"]}
+
+-- input.txt --
+INITIAL
+CONTENT
+
+-- input.txt,v --
+head	1.1;
+access;
+symbols;
+locks;
+comment	@# @;
+
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.1
+log
+@initial
+@
+text
+@INITIAL
+CONTENT
+@
+
+-- tests.txt --
+ci
+
+-- tests.md --
+ci
+
+-- expected.txt,v --
+head	1.5;
+access;
+symbols;
+locks;
+comment	@# @;
+
+
+1.5
+date	2020.01.02.00.00.00;	author tester;	state Exp;
+branches;
+next	1.1;
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.5
+log
+@forced-skip
+@
+text
+@NEW
+CONTENT
+@
+
+
+1.1
+log
+@initial
+@
+text
+@d1 1
+a1 1
+INITIAL
+@

--- a/testdata/txtar/operations/72-ci-force-branch.sh
+++ b/testdata/txtar/operations/72-ci-force-branch.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NAME="72-ci-force-branch"
+OUT="$OUTDIR/$NAME.txtar"
+TMP_OUT="$OUTDIR/.$NAME.txtar.tmp.$$"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp" "$TMP_OUT"' EXIT
+cd "$tmp"
+
+# Create initial content
+printf "INITIAL\nCONTENT\n" > file.txt
+
+# setup: create 1.1
+ci -q -i -u -m"initial" -wtester -d'2020-01-01 00:00:00Z' file.txt </dev/null
+rcs -q -U file.txt
+
+# Prepare input state
+cp file.txt   input.txt
+cp file.txt,v input.txt,v
+
+# Modify file if needed
+# ensure file is writable as ci -u makes it read-only
+chmod +w file.txt
+printf 'BRANCH\nCONTENT\n' > file.txt
+
+# execution
+# We run the command to generate the expected output
+ci -q -u -f1.1.1.1 -m'forced-branch' -wtester -d'2020-01-02 00:00:00Z' file.txt </dev/null
+
+cat > "$TMP_OUT" <<EOF
+-- description.txt --
+ci -f1.1.1.1 forces creation of branch 1.1.1
+
+-- options.conf --
+{"args": ["-q", "-u", "-f1.1.1.1", "-m", "forced-branch", "-wtester", "-d", "2020-01-02 00:00:00Z", "input.txt"]}
+
+-- input.txt --
+$(cat input.txt)
+
+-- input.txt,v --
+$(cat input.txt,v)
+
+-- tests.txt --
+ci
+
+-- tests.md --
+ci
+
+-- expected.txt,v --
+$(cat file.txt,v)
+EOF
+
+mv -f "$TMP_OUT" "$OUT"

--- a/testdata/txtar/operations/72-ci-force-branch.txtar
+++ b/testdata/txtar/operations/72-ci-force-branch.txtar
@@ -1,0 +1,86 @@
+-- description.txt --
+ci -f1.1.1.1 forces creation of branch 1.1.1
+
+-- options.conf --
+{"args": ["-q", "-u", "-f1.1.1.1", "-m", "forced-branch", "-wtester", "-d", "2020-01-02 00:00:00Z", "input.txt"]}
+
+-- input.txt --
+INITIAL
+CONTENT
+
+-- input.txt,v --
+head	1.1;
+access;
+symbols;
+locks;
+comment	@# @;
+
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.1
+log
+@initial
+@
+text
+@INITIAL
+CONTENT
+@
+
+-- tests.txt --
+ci
+
+-- tests.md --
+ci
+
+-- expected.txt,v --
+head	1.1;
+access;
+symbols;
+locks;
+comment	@# @;
+
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches
+	1.1.1.1;
+next	;
+
+1.1.1.1
+date	2020.01.02.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.1
+log
+@initial
+@
+text
+@INITIAL
+CONTENT
+@
+
+
+1.1.1.1
+log
+@forced-branch
+@
+text
+@d1 1
+a1 1
+BRANCH
+@

--- a/testdata/txtar/operations/99-ci-force-rev-nochange.sh
+++ b/testdata/txtar/operations/99-ci-force-rev-nochange.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NAME="99-ci-force-rev-nochange"
+OUT="$OUTDIR/$NAME.txtar"
+TMP_OUT="$OUTDIR/.$NAME.txtar.tmp.$$"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp" "$TMP_OUT"' EXIT
+cd "$tmp"
+
+# Create initial content
+printf "INITIAL\nCONTENT\n" > file.txt
+
+# setup: create 1.1
+ci -q -i -u -m"initial" -wtester -d'2020-01-01 00:00:00Z' file.txt </dev/null
+rcs -q -U file.txt
+
+# Prepare input state
+cp file.txt   input.txt
+cp file.txt,v input.txt,v
+
+# Modify file if needed
+# ensure file is writable as ci -u makes it read-only
+chmod +w file.txt
+:
+
+# execution
+# We run the command to generate the expected output
+ci -q -u -f1.3 -m'forced-nochange-skip' -wtester -d'2020-01-02 00:00:00Z' file.txt </dev/null
+
+cat > "$TMP_OUT" <<EOF
+-- description.txt --
+ci -f1.3 forces revision 1.3 even with no content change
+
+-- options.conf --
+{"args": ["-q", "-u", "-f1.3", "-m", "forced-nochange-skip", "-wtester", "-d", "2020-01-02 00:00:00Z", "input.txt"]}
+
+-- input.txt --
+$(cat input.txt)
+
+-- input.txt,v --
+$(cat input.txt,v)
+
+-- tests.txt --
+ci
+
+-- tests.md --
+ci
+
+-- expected.txt,v --
+$(cat file.txt,v)
+EOF
+
+mv -f "$TMP_OUT" "$OUT"

--- a/testdata/txtar/operations/99-ci-force-rev-nochange.txtar
+++ b/testdata/txtar/operations/99-ci-force-rev-nochange.txtar
@@ -1,0 +1,82 @@
+-- description.txt --
+ci -f1.3 forces revision 1.3 even with no content change
+
+-- options.conf --
+{"args": ["-q", "-u", "-f1.3", "-m", "forced-nochange-skip", "-wtester", "-d", "2020-01-02 00:00:00Z", "input.txt"]}
+
+-- input.txt --
+INITIAL
+CONTENT
+
+-- input.txt,v --
+head	1.1;
+access;
+symbols;
+locks;
+comment	@# @;
+
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.1
+log
+@initial
+@
+text
+@INITIAL
+CONTENT
+@
+
+-- tests.txt --
+ci
+
+-- tests.md --
+ci
+
+-- expected.txt,v --
+head	1.3;
+access;
+symbols;
+locks;
+comment	@# @;
+
+
+1.3
+date	2020.01.02.00.00.00;	author tester;	state Exp;
+branches;
+next	1.1;
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.3
+log
+@forced-nochange-skip
+@
+text
+@INITIAL
+CONTENT
+@
+
+
+1.1
+log
+@initial
+@
+text
+@@


### PR DESCRIPTION
Added new test cases for `ci -f` operations as requested.
- `55-ci-force-rev-skip.txtar` and `.sh`
- `72-ci-force-branch.txtar` and `.sh`
- `99-ci-force-rev-nochange.txtar` and `.sh`

The shell scripts generate the `.txtar` files using the system `rcs` and `ci` commands.
The tests are currently failing in `go test` because the `ci` test type is not supported in `txtar_test.go`, which is expected.

---
*PR created automatically by Jules for task [6181521895935642792](https://jules.google.com/task/6181521895935642792) started by @arran4*