### PR TITLE
Add tests for ci -k[REV] operations

### DIFF
--- a/testdata/txtar/operations/50-ci-k-rev-from-keyword.sh
+++ b/testdata/txtar/operations/50-ci-k-rev-from-keyword.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUT="50-ci-k-rev-from-keyword.txtar"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+
+cat > input.txt <<'EOF'
+$Id: input.txt,v 1.5 2020/01/01 12:00:00 tester Exp $
+Some content.
+EOF
+
+ci -q -k -u -m"forced 1.5" -t- input.txt
+
+cat > "$OLDPWD/$OUT" <<EOF
+-- description.txt --
+ci -k uses revision from keywords
+
+-- options.conf --
+{"args": ["-q","-k","-u","-m","forced 1.5","-t-","input.txt"] }
+
+-- input.txt --
+\$Id: input.txt,v 1.5 2020/01/01 12:00:00 tester Exp \$
+Some content.
+
+-- tests.txt --
+ci
+
+-- expected.txt,v --
+$(cat input.txt,v)
+EOF

--- a/testdata/txtar/operations/50-ci-k-rev-from-keyword.txtar
+++ b/testdata/txtar/operations/50-ci-k-rev-from-keyword.txtar
@@ -1,0 +1,39 @@
+-- description.txt --
+ci -k uses revision from keywords
+
+-- options.conf --
+{"args": ["-q","-k","-u","-m","forced 1.5","-t-","input.txt"] }
+
+-- input.txt --
+$Id: input.txt,v 1.5 2020/01/01 12:00:00 tester Exp $
+Some content.
+
+-- tests.txt --
+ci
+
+-- expected.txt,v --
+head	1.5;
+access;
+symbols;
+locks; strict;
+comment	@# @;
+
+
+1.5
+date	2020.01.01.12.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.5
+log
+@forced 1.5
+@
+text
+@$Id: input.txt,v 1.5 2020/01/01 12:00:00 tester Exp $
+Some content.
+@

--- a/testdata/txtar/operations/51-ci-k-rev-override.sh
+++ b/testdata/txtar/operations/51-ci-k-rev-override.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUT="51-ci-k-rev-override.txtar"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+
+cat > input.txt <<'EOF'
+$Id: input.txt,v 1.5 2020/01/01 12:00:00 tester Exp $
+Some content.
+EOF
+
+ci -q -k2.1 -u -m"forced 2.1" -t- input.txt
+
+cat > "$OLDPWD/$OUT" <<EOF
+-- description.txt --
+ci -kREV overrides revision from keywords but uses other metadata
+
+-- options.conf --
+{"args": ["-q","-k2.1","-u","-m","forced 2.1","-t-","input.txt"] }
+
+-- input.txt --
+\$Id: input.txt,v 1.5 2020/01/01 12:00:00 tester Exp \$
+Some content.
+
+-- tests.txt --
+ci
+
+-- expected.txt,v --
+$(cat input.txt,v)
+EOF

--- a/testdata/txtar/operations/51-ci-k-rev-override.txtar
+++ b/testdata/txtar/operations/51-ci-k-rev-override.txtar
@@ -1,0 +1,39 @@
+-- description.txt --
+ci -kREV overrides revision from keywords but uses other metadata
+
+-- options.conf --
+{"args": ["-q","-k2.1","-u","-m","forced 2.1","-t-","input.txt"] }
+
+-- input.txt --
+$Id: input.txt,v 1.5 2020/01/01 12:00:00 tester Exp $
+Some content.
+
+-- tests.txt --
+ci
+
+-- expected.txt,v --
+head	2.1;
+access;
+symbols;
+locks; strict;
+comment	@# @;
+
+
+2.1
+date	2020.01.01.12.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+2.1
+log
+@forced 2.1
+@
+text
+@$Id: input.txt,v 1.5 2020/01/01 12:00:00 tester Exp $
+Some content.
+@

--- a/testdata/txtar/operations/52-ci-k-preserve-metadata.sh
+++ b/testdata/txtar/operations/52-ci-k-preserve-metadata.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUT="52-ci-k-preserve-metadata.txtar"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+
+cat > input.txt <<'EOF'
+$Id: input.txt,v 1.1 1990/01/01 12:00:00 oldguy Exp $
+Old content.
+EOF
+
+ci -q -k -u -m"restored" -t- input.txt
+
+cat > "$OLDPWD/$OUT" <<EOF
+-- description.txt --
+ci -k preserves old metadata from keywords
+
+-- options.conf --
+{"args": ["-q","-k","-u","-m","restored","-t-","input.txt"] }
+
+-- input.txt --
+\$Id: input.txt,v 1.1 1990/01/01 12:00:00 oldguy Exp \$
+Old content.
+
+-- tests.txt --
+ci
+
+-- expected.txt,v --
+$(cat input.txt,v)
+EOF

--- a/testdata/txtar/operations/52-ci-k-preserve-metadata.txtar
+++ b/testdata/txtar/operations/52-ci-k-preserve-metadata.txtar
@@ -1,0 +1,39 @@
+-- description.txt --
+ci -k preserves old metadata from keywords
+
+-- options.conf --
+{"args": ["-q","-k","-u","-m","restored","-t-","input.txt"] }
+
+-- input.txt --
+$Id: input.txt,v 1.1 1990/01/01 12:00:00 oldguy Exp $
+Old content.
+
+-- tests.txt --
+ci
+
+-- expected.txt,v --
+head	1.1;
+access;
+symbols;
+locks; strict;
+comment	@# @;
+
+
+1.1
+date	90.01.01.12.00.00;	author oldguy;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.1
+log
+@restored
+@
+text
+@$Id: input.txt,v 1.1 1990/01/01 12:00:00 oldguy Exp $
+Old content.
+@


### PR DESCRIPTION
Added 3 new txtar test cases for `ci -k` functionality along with their shell script generators. These tests verify correct revision inference and metadata preservation when using the `-k` flag.


---
*PR created automatically by Jules for task [3095984084372918840](https://jules.google.com/task/3095984084372918840) started by @arran4*