### PR TITLE
Add ci operation tests for -d and -z flags

### DIFF
--- a/testdata/txtar/operations/53-ci-date-simple.sh
+++ b/testdata/txtar/operations/53-ci-date-simple.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+
+OUT="53-ci-date-simple.txtar"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+
+cat > file.txt <<'EOF'
+A clock unwinds its shadow into rain,
+While silver echoes fold a paper sky;
+EOF
+
+ci -q -i -u -m"r1" -wtester -d"2022-02-02 12:00:00-08:00" file.txt </dev/null
+
+cat > "$OLDPWD/$OUT" <<EOF
+-- description.txt --
+ci checkin with explicit date offset
+
+-- options.conf --
+{"args": ["-q","-i","-u","-m","r1","-wtester","-d","2022-02-02 12:00:00-08:00","input.txt"] }
+
+-- input.txt --
+A clock unwinds its shadow into rain,
+While silver echoes fold a paper sky;
+
+-- tests.txt --
+ci
+
+-- expected.txt,v --
+$(cat file.txt,v)
+EOF

--- a/testdata/txtar/operations/53-ci-date-simple.txtar
+++ b/testdata/txtar/operations/53-ci-date-simple.txtar
@@ -1,0 +1,39 @@
+-- description.txt --
+ci checkin with explicit date offset
+
+-- options.conf --
+{"args": ["-q","-i","-u","-m","r1","-wtester","-d","2022-02-02 12:00:00-08:00","input.txt"] }
+
+-- input.txt --
+A clock unwinds its shadow into rain,
+While silver echoes fold a paper sky;
+
+-- tests.txt --
+ci
+
+-- expected.txt,v --
+head	1.1;
+access;
+symbols;
+locks; strict;
+comment	@# @;
+
+
+1.1
+date	2022.02.02.20.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.1
+log
+@r1
+@
+text
+@A clock unwinds its shadow into rain,
+While silver echoes fold a paper sky;
+@

--- a/testdata/txtar/operations/67-ci-zone-simple.sh
+++ b/testdata/txtar/operations/67-ci-zone-simple.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+
+OUT="67-ci-zone-simple.txtar"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+
+cat > file.txt <<'EOF'
+A clock unwinds its shadow into rain,
+While silver echoes fold a paper sky;
+EOF
+
+ci -q -i -u -m"r1" -wtester -z-0500 -d"2022-03-03 12:00:00" file.txt </dev/null
+
+cat > "$OLDPWD/$OUT" <<EOF
+-- description.txt --
+ci checkin with -z offset and date without offset
+
+-- options.conf --
+{"args": ["-q","-i","-u","-m","r1","-wtester","-z","-0500","-d","2022-03-03 12:00:00","input.txt"] }
+
+-- input.txt --
+A clock unwinds its shadow into rain,
+While silver echoes fold a paper sky;
+
+-- tests.txt --
+ci
+
+-- expected.txt,v --
+$(cat file.txt,v)
+EOF

--- a/testdata/txtar/operations/67-ci-zone-simple.txtar
+++ b/testdata/txtar/operations/67-ci-zone-simple.txtar
@@ -1,0 +1,39 @@
+-- description.txt --
+ci checkin with -z offset and date without offset
+
+-- options.conf --
+{"args": ["-q","-i","-u","-m","r1","-wtester","-z","-0500","-d","2022-03-03 12:00:00","input.txt"] }
+
+-- input.txt --
+A clock unwinds its shadow into rain,
+While silver echoes fold a paper sky;
+
+-- tests.txt --
+ci
+
+-- expected.txt,v --
+head	1.1;
+access;
+symbols;
+locks; strict;
+comment	@# @;
+
+
+1.1
+date	2022.03.03.17.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.1
+log
+@r1
+@
+text
+@A clock unwinds its shadow into rain,
+While silver echoes fold a paper sky;
+@

--- a/testdata/txtar/operations/81-ci-date-zone.sh
+++ b/testdata/txtar/operations/81-ci-date-zone.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+export TZ=EST5
+
+
+OUT="81-ci-date-zone.txtar"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+
+cat > file.txt <<'EOF'
+A clock unwinds its shadow into rain,
+While silver echoes fold a paper sky;
+EOF
+
+ci -q -i -u -m"r1" -wtester -zLT -d"2022-04-04 12:00:00" file.txt </dev/null
+
+cat > "$OLDPWD/$OUT" <<EOF
+-- description.txt --
+ci checkin with -zLT and TZ env var
+
+-- options.conf --
+{"args": ["-q","-i","-u","-m","r1","-wtester","-z","LT","-d","2022-04-04 12:00:00","input.txt"] }
+
+-- input.txt --
+A clock unwinds its shadow into rain,
+While silver echoes fold a paper sky;
+
+-- tests.txt --
+ci
+
+-- expected.txt,v --
+$(cat file.txt,v)
+EOF

--- a/testdata/txtar/operations/81-ci-date-zone.txtar
+++ b/testdata/txtar/operations/81-ci-date-zone.txtar
@@ -1,0 +1,39 @@
+-- description.txt --
+ci checkin with -zLT and TZ env var
+
+-- options.conf --
+{"args": ["-q","-i","-u","-m","r1","-wtester","-z","LT","-d","2022-04-04 12:00:00","input.txt"] }
+
+-- input.txt --
+A clock unwinds its shadow into rain,
+While silver echoes fold a paper sky;
+
+-- tests.txt --
+ci
+
+-- expected.txt,v --
+head	1.1;
+access;
+symbols;
+locks; strict;
+comment	@# @;
+
+
+1.1
+date	2022.04.04.17.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.1
+log
+@r1
+@
+text
+@A clock unwinds its shadow into rain,
+While silver echoes fold a paper sky;
+@


### PR DESCRIPTION
Added 3 new txtar tests for `ci` operation covering `-d` and `-z` flags usage, including explicit offsets, implicit offsets via `-z`, and `LT` timezone with `TZ` env var. The tests follow the existing convention of using a shell script to generate the txtar archive.

---
*PR created automatically by Jules for task [9895393076783749361](https://jules.google.com/task/9895393076783749361) started by @arran4*