### PR TITLE
Add co operation tests for -r flag usage

### DIFF
--- a/testdata/txtar/operations/3551-co-checkout-branch.sh
+++ b/testdata/txtar/operations/3551-co-checkout-branch.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUT="3551-co-checkout-branch.txtar"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+
+printf "MAIN\n" > file.txt
+ci -q -i -u -m"r1" -wtester -d'2020-01-01 00:00:00Z' file.txt </dev/null
+
+# Create a branch off 1.1
+rcs -q -U file.txt
+co -q -l1.1 file.txt
+printf "BRANCH\n" > file.txt
+ci -q -u -r1.1.1.1 -m"r1.1.1.1" -wtester -d'2020-01-02 00:00:00Z' file.txt </dev/null
+
+cp file.txt,v input.txt,v
+rm file.txt
+
+# Expected output is revision 1.1.1.1 content
+printf "BRANCH\n" > expected_output.txt
+
+# Check against system co
+co -q -r1.1.1.1 -p file.txt > system_co_output.txt
+diff expected_output.txt system_co_output.txt
+
+cat > "$OLDPWD/$OUT" <<EOF
+-- description.txt --
+co checkout branch revision 1.1.1.1
+
+-- options.conf --
+{"args": ["-q","-r1.1.1.1","input.txt"] }
+
+-- input.txt,v --
+$(cat input.txt,v)
+
+-- tests.txt --
+co
+
+-- expected.txt --
+$(cat expected_output.txt)
+EOF

--- a/testdata/txtar/operations/3551-co-checkout-branch.txtar
+++ b/testdata/txtar/operations/3551-co-checkout-branch.txtar
@@ -1,0 +1,54 @@
+-- description.txt --
+co checkout branch revision 1.1.1.1
+
+-- options.conf --
+{"args": ["-q","-r1.1.1.1","input.txt"] }
+
+-- input.txt,v --
+head	1.1;
+access;
+symbols;
+locks;
+comment	@# @;
+
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches
+	1.1.1.1;
+next	;
+
+1.1.1.1
+date	2020.01.02.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.1
+log
+@r1
+@
+text
+@MAIN
+@
+
+
+1.1.1.1
+log
+@r1.1.1.1
+@
+text
+@d1 1
+a1 1
+BRANCH
+@
+
+-- tests.txt --
+co
+
+-- expected.txt --
+BRANCH

--- a/testdata/txtar/operations/8749-co-checkout-older-rev.sh
+++ b/testdata/txtar/operations/8749-co-checkout-older-rev.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUT="8749-co-checkout-older-rev.txtar"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+
+printf "ONE\n" > file.txt
+ci -q -i -u -m"r1" -wtester -d'2020-01-01 00:00:00Z' file.txt </dev/null
+
+rcs -q -U file.txt
+chmod u+w file.txt
+printf "ONE\nTWO\n" > file.txt
+ci -q -u -m"r2" -wtester -d'2020-01-02 00:00:00Z' file.txt </dev/null
+
+rcs -q -U file.txt
+chmod u+w file.txt
+printf "ONE\nTWO\nTHREE\n" > file.txt
+ci -q -u -m"r3" -wtester -d'2020-01-03 00:00:00Z' file.txt </dev/null
+
+cp file.txt,v input.txt,v
+rm file.txt
+
+# Expected output is revision 1.1 content
+printf "ONE\n" > expected_output.txt
+
+# Check against system co
+co -q -r1.1 -p file.txt > system_co_output.txt
+diff expected_output.txt system_co_output.txt
+
+cat > "$OLDPWD/$OUT" <<EOF
+-- description.txt --
+co checkout older revision 1.1 when 1.3 is head
+
+-- options.conf --
+{"args": ["-q","-r1.1","input.txt"] }
+
+-- input.txt,v --
+$(cat input.txt,v)
+
+-- tests.txt --
+co
+
+-- expected.txt --
+$(cat expected_output.txt)
+EOF

--- a/testdata/txtar/operations/8749-co-checkout-older-rev.txtar
+++ b/testdata/txtar/operations/8749-co-checkout-older-rev.txtar
@@ -1,0 +1,67 @@
+-- description.txt --
+co checkout older revision 1.1 when 1.3 is head
+
+-- options.conf --
+{"args": ["-q","-r1.1","input.txt"] }
+
+-- input.txt,v --
+head	1.3;
+access;
+symbols;
+locks;
+comment	@# @;
+
+
+1.3
+date	2020.01.03.00.00.00;	author tester;	state Exp;
+branches;
+next	1.2;
+
+1.2
+date	2020.01.02.00.00.00;	author tester;	state Exp;
+branches;
+next	1.1;
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.3
+log
+@r3
+@
+text
+@ONE
+TWO
+THREE
+@
+
+
+1.2
+log
+@r2
+@
+text
+@d3 1
+@
+
+
+1.1
+log
+@r1
+@
+text
+@d2 1
+@
+
+-- tests.txt --
+co
+
+-- expected.txt --
+ONE

--- a/testdata/txtar/operations/9852-co-checkout-head-explicit.sh
+++ b/testdata/txtar/operations/9852-co-checkout-head-explicit.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUT="9852-co-checkout-head-explicit.txtar"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+
+printf "ONE\n" > file.txt
+ci -q -i -u -m"r1" -wtester -d'2020-01-01 00:00:00Z' file.txt </dev/null
+
+rcs -q -U file.txt
+chmod u+w file.txt
+printf "ONE\nTWO\n" > file.txt
+ci -q -u -m"r2" -wtester -d'2020-01-02 00:00:00Z' file.txt </dev/null
+
+cp file.txt,v input.txt,v
+rm file.txt
+
+# Expected output is revision 1.2 content
+printf "ONE\nTWO\n" > expected_output.txt
+
+# Check against system co
+co -q -r1.2 -p file.txt > system_co_output.txt
+diff expected_output.txt system_co_output.txt
+
+cat > "$OLDPWD/$OUT" <<EOF
+-- description.txt --
+co checkout head revision explicitly (1.2)
+
+-- options.conf --
+{"args": ["-q","-r1.2","input.txt"] }
+
+-- input.txt,v --
+$(cat input.txt,v)
+
+-- tests.txt --
+co
+
+-- expected.txt --
+$(cat expected_output.txt)
+EOF

--- a/testdata/txtar/operations/9852-co-checkout-head-explicit.txtar
+++ b/testdata/txtar/operations/9852-co-checkout-head-explicit.txtar
@@ -1,0 +1,53 @@
+-- description.txt --
+co checkout head revision explicitly (1.2)
+
+-- options.conf --
+{"args": ["-q","-r1.2","input.txt"] }
+
+-- input.txt,v --
+head	1.2;
+access;
+symbols;
+locks;
+comment	@# @;
+
+
+1.2
+date	2020.01.02.00.00.00;	author tester;	state Exp;
+branches;
+next	1.1;
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.2
+log
+@r2
+@
+text
+@ONE
+TWO
+@
+
+
+1.1
+log
+@r1
+@
+text
+@d2 1
+@
+
+-- tests.txt --
+co
+
+-- expected.txt --
+ONE
+TWO


### PR DESCRIPTION
This PR adds three new test cases to `testdata/txtar/operations` to improve coverage of the `co` command, specifically focusing on the `-r` flag as requested.

The new tests are:
1.  **Checking out a branch revision** (`3551-co-checkout-branch.txtar`): Verifies `co -r1.1.1.1`.
2.  **Checking out an older revision** (`8749-co-checkout-older-rev.txtar`): Verifies `co -r1.1` when `1.3` is head.
3.  **Checking out head explicitly** (`9852-co-checkout-head-explicit.txtar`): Verifies `co -r1.2` when `1.2` is head.

Corresponding shell scripts are included for each test case, which were used to generate the `.txtar` files using the system's `rcs` tools. This ensures the input RCS files and expected outputs are correct. Random prefixes were used for filenames to avoid collisions.

---
*PR created automatically by Jules for task [18279444292366187451](https://jules.google.com/task/18279444292366187451) started by @arran4*