### PR TITLE
Add ci operation tests for revision and locking flags

### DIFF
--- a/testdata/txtar/operations/19-ci-u.sh
+++ b/testdata/txtar/operations/19-ci-u.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUT="19-ci-u.txtar"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+
+# 1. Setup
+printf 'Initial content\n' > file.txt
+ci -q -i -t-desc -minitial -wtester -d'2020-01-01 00:00:00Z' file.txt </dev/null
+co -q -l file.txt
+
+# 2. Save initial RCS state (input.txt,v)
+# We want input.txt,v to be the state BEFORE the test command.
+cp file.txt,v input.txt,v
+
+# 3. Modify working file
+printf "Unlocked content
+" > file.txt
+
+# 4. Save working file state (input.txt)
+# We want input.txt to be the state BEFORE the test command (i.e. the modified content that will be checked in).
+cp file.txt input.txt
+
+# 5. Run the test command
+ci -q -u '-munlocked checkin' -wtester '-d2020-01-02 00:00:00Z' file.txt </dev/null
+
+# 6. Generate txtar
+cat > "$OLDPWD/$OUT" <<EOF
+-- description.txt --
+ci checkin and unlock
+
+-- options.conf --
+{"args": ["-q", "-u", "-munlocked checkin", "-wtester", "-d2020-01-02 00:00:00Z", "input.txt"]}
+
+-- input.txt --
+$(cat input.txt)
+
+-- input.txt,v --
+$(cat input.txt,v)
+
+-- tests.txt --
+ci
+
+-- expected.txt,v --
+$(cat file.txt,v)
+EOF

--- a/testdata/txtar/operations/19-ci-u.txtar
+++ b/testdata/txtar/operations/19-ci-u.txtar
@@ -1,0 +1,82 @@
+-- description.txt --
+ci checkin and unlock
+
+-- options.conf --
+{"args": ["-q", "-u", "-munlocked checkin", "-wtester", "-d2020-01-02 00:00:00Z", "input.txt"]}
+
+-- input.txt --
+Unlocked content
+
+-- input.txt,v --
+head	1.1;
+access;
+symbols;
+locks
+	tester:1.1; strict;
+comment	@# @;
+
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@desc
+@
+
+
+1.1
+log
+@initial
+@
+text
+@Initial content
+@
+
+-- tests.txt --
+ci
+
+-- expected.txt,v --
+head	1.2;
+access;
+symbols;
+locks; strict;
+comment	@# @;
+
+
+1.2
+date	2020.01.02.00.00.00;	author tester;	state Exp;
+branches;
+next	1.1;
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@desc
+@
+
+
+1.2
+log
+@unlocked checkin
+@
+text
+@Unlocked content
+@
+
+
+1.1
+log
+@initial
+@
+text
+@d1 1
+a1 1
+Initial content
+@

--- a/testdata/txtar/operations/53-ci-r.sh
+++ b/testdata/txtar/operations/53-ci-r.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUT="53-ci-r.txtar"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+
+# 1. Setup
+printf 'Initial content\n' > file.txt
+ci -q -i -t-desc -minitial -wtester -d'2020-01-01 00:00:00Z' file.txt </dev/null
+co -q -l file.txt
+
+# 2. Save initial RCS state (input.txt,v)
+# We want input.txt,v to be the state BEFORE the test command.
+cp file.txt,v input.txt,v
+
+# 3. Modify working file
+printf "Modified content
+" > file.txt
+
+# 4. Save working file state (input.txt)
+# We want input.txt to be the state BEFORE the test command (i.e. the modified content that will be checked in).
+cp file.txt input.txt
+
+# 5. Run the test command
+ci -q -r1.5 '-mjump to 1.5' -wtester '-d2020-01-02 00:00:00Z' file.txt </dev/null
+
+# 6. Generate txtar
+cat > "$OLDPWD/$OUT" <<EOF
+-- description.txt --
+ci checkin revision 1.5
+
+-- options.conf --
+{"args": ["-q", "-r1.5", "-mjump to 1.5", "-wtester", "-d2020-01-02 00:00:00Z", "input.txt"]}
+
+-- input.txt --
+$(cat input.txt)
+
+-- input.txt,v --
+$(cat input.txt,v)
+
+-- tests.txt --
+ci
+
+-- expected.txt,v --
+$(cat file.txt,v)
+EOF

--- a/testdata/txtar/operations/53-ci-r.txtar
+++ b/testdata/txtar/operations/53-ci-r.txtar
@@ -1,0 +1,82 @@
+-- description.txt --
+ci checkin revision 1.5
+
+-- options.conf --
+{"args": ["-q", "-r1.5", "-mjump to 1.5", "-wtester", "-d2020-01-02 00:00:00Z", "input.txt"]}
+
+-- input.txt --
+Modified content
+
+-- input.txt,v --
+head	1.1;
+access;
+symbols;
+locks
+	tester:1.1; strict;
+comment	@# @;
+
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@desc
+@
+
+
+1.1
+log
+@initial
+@
+text
+@Initial content
+@
+
+-- tests.txt --
+ci
+
+-- expected.txt,v --
+head	1.5;
+access;
+symbols;
+locks; strict;
+comment	@# @;
+
+
+1.5
+date	2020.01.02.00.00.00;	author tester;	state Exp;
+branches;
+next	1.1;
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@desc
+@
+
+
+1.5
+log
+@jump to 1.5
+@
+text
+@Modified content
+@
+
+
+1.1
+log
+@initial
+@
+text
+@d1 1
+a1 1
+Initial content
+@

--- a/testdata/txtar/operations/82-ci-l.sh
+++ b/testdata/txtar/operations/82-ci-l.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUT="82-ci-l.txtar"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+
+# 1. Setup
+printf 'Initial content\n' > file.txt
+ci -q -i -t-desc -minitial -wtester -d'2020-01-01 00:00:00Z' file.txt </dev/null
+co -q -l file.txt
+
+# 2. Save initial RCS state (input.txt,v)
+# We want input.txt,v to be the state BEFORE the test command.
+cp file.txt,v input.txt,v
+
+# 3. Modify working file
+printf "Locked content
+" > file.txt
+
+# 4. Save working file state (input.txt)
+# We want input.txt to be the state BEFORE the test command (i.e. the modified content that will be checked in).
+cp file.txt input.txt
+
+# 5. Run the test command
+ci -q -l '-mlocked checkin' -wtester '-d2020-01-02 00:00:00Z' file.txt </dev/null
+
+# 6. Generate txtar
+cat > "$OLDPWD/$OUT" <<EOF
+-- description.txt --
+ci checkin and lock
+
+-- options.conf --
+{"args": ["-q", "-l", "-mlocked checkin", "-wtester", "-d2020-01-02 00:00:00Z", "input.txt"]}
+
+-- input.txt --
+$(cat input.txt)
+
+-- input.txt,v --
+$(cat input.txt,v)
+
+-- tests.txt --
+ci
+
+-- expected.txt,v --
+$(cat file.txt,v)
+EOF

--- a/testdata/txtar/operations/82-ci-l.txtar
+++ b/testdata/txtar/operations/82-ci-l.txtar
@@ -1,0 +1,83 @@
+-- description.txt --
+ci checkin and lock
+
+-- options.conf --
+{"args": ["-q", "-l", "-mlocked checkin", "-wtester", "-d2020-01-02 00:00:00Z", "input.txt"]}
+
+-- input.txt --
+Locked content
+
+-- input.txt,v --
+head	1.1;
+access;
+symbols;
+locks
+	tester:1.1; strict;
+comment	@# @;
+
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@desc
+@
+
+
+1.1
+log
+@initial
+@
+text
+@Initial content
+@
+
+-- tests.txt --
+ci
+
+-- expected.txt,v --
+head	1.2;
+access;
+symbols;
+locks
+	tester:1.2; strict;
+comment	@# @;
+
+
+1.2
+date	2020.01.02.00.00.00;	author tester;	state Exp;
+branches;
+next	1.1;
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@desc
+@
+
+
+1.2
+log
+@locked checkin
+@
+text
+@Locked content
+@
+
+
+1.1
+log
+@initial
+@
+text
+@d1 1
+a1 1
+Initial content
+@

--- a/testdata/txtar/operations/91-ci-M.sh
+++ b/testdata/txtar/operations/91-ci-M.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUT="91-ci-M.txtar"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+
+# 1. Setup
+printf 'Initial content\n' > file.txt
+ci -q -i -t-desc -minitial -wtester -d'2020-01-01 00:00:00Z' file.txt </dev/null
+co -q -l file.txt
+
+# 2. Save initial RCS state (input.txt,v)
+# We want input.txt,v to be the state BEFORE the test command.
+cp file.txt,v input.txt,v
+
+# 3. Modify working file
+printf "Reset mtime content
+" > file.txt
+
+# 4. Save working file state (input.txt)
+# We want input.txt to be the state BEFORE the test command (i.e. the modified content that will be checked in).
+cp file.txt input.txt
+
+# 5. Run the test command
+ci -q -u -M '-mreset mtime' -wtester '-d2020-01-02 00:00:00Z' file.txt </dev/null
+
+# 6. Generate txtar
+cat > "$OLDPWD/$OUT" <<EOF
+-- description.txt --
+ci checkin and reset mtime
+
+-- options.conf --
+{"args": ["-q", "-u", "-M", "-mreset mtime", "-wtester", "-d2020-01-02 00:00:00Z", "input.txt"]}
+
+-- input.txt --
+$(cat input.txt)
+
+-- input.txt,v --
+$(cat input.txt,v)
+
+-- tests.txt --
+ci
+
+-- expected.txt,v --
+$(cat file.txt,v)
+EOF

--- a/testdata/txtar/operations/91-ci-M.txtar
+++ b/testdata/txtar/operations/91-ci-M.txtar
@@ -1,0 +1,82 @@
+-- description.txt --
+ci checkin and reset mtime
+
+-- options.conf --
+{"args": ["-q", "-u", "-M", "-mreset mtime", "-wtester", "-d2020-01-02 00:00:00Z", "input.txt"]}
+
+-- input.txt --
+Reset mtime content
+
+-- input.txt,v --
+head	1.1;
+access;
+symbols;
+locks
+	tester:1.1; strict;
+comment	@# @;
+
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@desc
+@
+
+
+1.1
+log
+@initial
+@
+text
+@Initial content
+@
+
+-- tests.txt --
+ci
+
+-- expected.txt,v --
+head	1.2;
+access;
+symbols;
+locks; strict;
+comment	@# @;
+
+
+1.2
+date	2020.01.02.00.00.00;	author tester;	state Exp;
+branches;
+next	1.1;
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@desc
+@
+
+
+1.2
+log
+@reset mtime
+@
+text
+@Reset mtime content
+@
+
+
+1.1
+log
+@initial
+@
+text
+@d1 1
+a1 1
+Initial content
+@


### PR DESCRIPTION
This change adds 4 new test cases to `testdata/txtar/operations`:
- `53-ci-r.txtar`: Tests `ci -r` (checkin specific revision).
- `82-ci-l.txtar`: Tests `ci -l` (checkin and keep locked).
- `19-ci-u.txtar`: Tests `ci -u` (checkin and unlock).
- `91-ci-M.txtar`: Tests `ci -u -M` (checkin, unlock, and reset mtime).

Each test includes a corresponding `.sh` script that generates the `.txtar` file using standard `rcs` commands (`ci`, `co`). This ensures the tests reflect standard RCS behavior. The generation logic ensures `input.txt` reflects the content being checked in, matching the `expected.txt,v` outcome.


---
*PR created automatically by Jules for task [13525074608295312350](https://jules.google.com/task/13525074608295312350) started by @arran4*