### PR TITLE
Add rcs comment leader operation tests

### DIFF
--- a/testdata/txtar/operations/1938-rcs-comment-leader-empty.sh
+++ b/testdata/txtar/operations/1938-rcs-comment-leader-empty.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT="$OUTDIR/1938-rcs-comment-leader-empty.txtar"
+TMP_OUT="$OUTDIR/.1938-rcs-comment-leader-empty.txtar.tmp.$$"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp" "$TMP_OUT"' EXIT
+cd "$tmp"
+
+printf "content\n" > file.txt
+
+# setup: create 1.1
+ci -q -i -u -m"r1" -wtester -d'2020-01-01 00:00:00Z' file.txt </dev/null
+
+cp file.txt   input.txt
+cp file.txt,v input.txt,v
+
+# execution
+rcs -c"" file.txt
+
+cat > "$TMP_OUT" <<EOF
+-- description.txt --
+rcs -c"" changes comment leader to empty
+
+-- options.conf --
+{"args": ["-c", "input.txt"] }
+
+-- input.txt --
+$(cat input.txt)
+
+-- input.txt,v --
+$(cat input.txt,v)
+
+-- tests.txt --
+rcs
+
+-- expected.txt,v --
+$(cat file.txt,v)
+EOF
+
+mv -f "$TMP_OUT" "$OUT"

--- a/testdata/txtar/operations/1938-rcs-comment-leader-empty.txtar
+++ b/testdata/txtar/operations/1938-rcs-comment-leader-empty.txtar
@@ -1,0 +1,62 @@
+-- description.txt --
+rcs -c"" changes comment leader to empty
+
+-- options.conf --
+{"args": ["-c", "input.txt"] }
+
+-- input.txt --
+content
+
+-- input.txt,v --
+head	1.1;
+access;
+symbols;
+locks; strict;
+comment	@# @;
+
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.1
+log
+@r1
+@
+text
+@content
+@
+
+-- tests.txt --
+rcs
+
+-- expected.txt,v --
+head	1.1;
+access;
+symbols;
+locks; strict;
+
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.1
+log
+@r1
+@
+text
+@content
+@

--- a/testdata/txtar/operations/3821-rcs-comment-leader-hash.sh
+++ b/testdata/txtar/operations/3821-rcs-comment-leader-hash.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT="$OUTDIR/3821-rcs-comment-leader-hash.txtar"
+TMP_OUT="$OUTDIR/.3821-rcs-comment-leader-hash.txtar.tmp.$$"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp" "$TMP_OUT"' EXIT
+cd "$tmp"
+
+printf "content\n" > file.txt
+
+# setup: create 1.1
+ci -q -i -u -m"r1" -wtester -d'2020-01-01 00:00:00Z' file.txt </dev/null
+
+cp file.txt   input.txt
+cp file.txt,v input.txt,v
+
+# execution
+rcs -c"# " file.txt
+
+cat > "$TMP_OUT" <<EOF
+-- description.txt --
+rcs -c# changes comment leader
+
+-- options.conf --
+{"args": ["-c# ", "input.txt"] }
+
+-- input.txt --
+$(cat input.txt)
+
+-- input.txt,v --
+$(cat input.txt,v)
+
+-- tests.txt --
+rcs
+
+-- expected.txt,v --
+$(cat file.txt,v)
+EOF
+
+mv -f "$TMP_OUT" "$OUT"

--- a/testdata/txtar/operations/3821-rcs-comment-leader-hash.txtar
+++ b/testdata/txtar/operations/3821-rcs-comment-leader-hash.txtar
@@ -1,0 +1,63 @@
+-- description.txt --
+rcs -c# changes comment leader
+
+-- options.conf --
+{"args": ["-c# ", "input.txt"] }
+
+-- input.txt --
+content
+
+-- input.txt,v --
+head	1.1;
+access;
+symbols;
+locks; strict;
+comment	@# @;
+
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.1
+log
+@r1
+@
+text
+@content
+@
+
+-- tests.txt --
+rcs
+
+-- expected.txt,v --
+head	1.1;
+access;
+symbols;
+locks; strict;
+comment	@# @;
+
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.1
+log
+@r1
+@
+text
+@content
+@

--- a/testdata/txtar/operations/7482-rcs-comment-leader-slash.sh
+++ b/testdata/txtar/operations/7482-rcs-comment-leader-slash.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT="$OUTDIR/7482-rcs-comment-leader-slash.txtar"
+TMP_OUT="$OUTDIR/.7482-rcs-comment-leader-slash.txtar.tmp.$$"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp" "$TMP_OUT"' EXIT
+cd "$tmp"
+
+printf "content\n" > file.txt
+
+# setup: create 1.1
+ci -q -i -u -m"r1" -wtester -d'2020-01-01 00:00:00Z' file.txt </dev/null
+
+cp file.txt   input.txt
+cp file.txt,v input.txt,v
+
+# execution
+rcs -c"// " file.txt
+
+cat > "$TMP_OUT" <<EOF
+-- description.txt --
+rcs -c// changes comment leader
+
+-- options.conf --
+{"args": ["-c// ", "input.txt"] }
+
+-- input.txt --
+$(cat input.txt)
+
+-- input.txt,v --
+$(cat input.txt,v)
+
+-- tests.txt --
+rcs
+
+-- expected.txt,v --
+$(cat file.txt,v)
+EOF
+
+mv -f "$TMP_OUT" "$OUT"

--- a/testdata/txtar/operations/7482-rcs-comment-leader-slash.txtar
+++ b/testdata/txtar/operations/7482-rcs-comment-leader-slash.txtar
@@ -1,0 +1,63 @@
+-- description.txt --
+rcs -c// changes comment leader
+
+-- options.conf --
+{"args": ["-c// ", "input.txt"] }
+
+-- input.txt --
+content
+
+-- input.txt,v --
+head	1.1;
+access;
+symbols;
+locks; strict;
+comment	@# @;
+
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.1
+log
+@r1
+@
+text
+@content
+@
+
+-- tests.txt --
+rcs
+
+-- expected.txt,v --
+head	1.1;
+access;
+symbols;
+locks; strict;
+comment	@// @;
+
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.1
+log
+@r1
+@
+text
+@content
+@


### PR DESCRIPTION
Added 3 new test cases in `testdata/txtar/operations` to verify `rcs` command behavior with the `-c` flag for setting comment leaders.
The tests cover:
1. Setting comment leader to `# ` (default-like).
2. Setting comment leader to `// ` (double slash).
3. Setting comment leader to empty string.

Each test includes a shell script to generate the test case using system `rcs` and the generated `.txtar` file.
The `options.conf` in the generated files reflects the expected arguments for `gorcs` execution.


---
*PR created automatically by Jules for task [9496972178996582655](https://jules.google.com/task/9496972178996582655) started by @arran4*