### PR TITLE
Add rcsdiff operation tests

### DIFF
--- a/testdata/txtar/operations/3878-rcsdiff-one-rev.sh
+++ b/testdata/txtar/operations/3878-rcsdiff-one-rev.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUT="3878-rcsdiff-one-rev.txtar"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+
+cat > file.txt <<'EOF'
+Line 1
+EOF
+ci -q -t-'desc' -m'r1' -d'2020-01-01 00:00:00Z' file.txt
+co -q -l file.txt
+echo 'Line 2' >> file.txt
+ci -q -m'r2' -d'2020-01-02 00:00:00Z' file.txt
+co -q -l file.txt
+echo 'Line 3' >> file.txt
+# At this point: 1.1 has Line 1; 1.2 has Line 1+Line 2; Working has Line 1+Line 2+Line 3
+
+# Run the command and capture output (allowing exit code 1 for diffs)
+rcsdiff -r1.1 file.txt > output.txt 2>&1 || true
+
+cat > "$OLDPWD/3878-rcsdiff-one-rev.txtar" <<EOF
+-- description.txt --
+rcsdiff -rREV (compare working file with revision)
+
+-- options.conf --
+{"args": ["-r1.1", "file.txt"] }
+
+-- input.txt --
+$(cat file.txt)
+
+-- tests.txt --
+rcsdiff
+
+-- input.txt,v --
+$(cat file.txt,v)
+
+-- expected.out --
+$(cat output.txt)
+EOF

--- a/testdata/txtar/operations/3878-rcsdiff-one-rev.txtar
+++ b/testdata/txtar/operations/3878-rcsdiff-one-rev.txtar
@@ -1,0 +1,65 @@
+-- description.txt --
+rcsdiff -rREV (compare working file with revision)
+
+-- options.conf --
+{"args": ["-r1.1", "file.txt"] }
+
+-- input.txt --
+Line 1
+Line 2
+Line 3
+
+-- tests.txt --
+rcsdiff
+
+-- input.txt,v --
+head	1.2;
+access;
+symbols;
+locks
+	tester:1.2; strict;
+comment	@# @;
+
+
+1.2
+date	2020.01.02.00.00.00;	author tester;	state Exp;
+branches;
+next	1.1;
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@desc
+@
+
+
+1.2
+log
+@r2
+@
+text
+@Line 1
+Line 2
+@
+
+
+1.1
+log
+@r1
+@
+text
+@d2 1
+@
+
+-- expected.out --
+===================================================================
+RCS file: file.txt,v
+retrieving revision 1.1
+diff -r1.1 file.txt
+1a2,3
+> Line 2
+> Line 3

--- a/testdata/txtar/operations/7579-rcsdiff-no-args.sh
+++ b/testdata/txtar/operations/7579-rcsdiff-no-args.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUT="7579-rcsdiff-no-args.txtar"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+
+cat > file.txt <<'EOF'
+Line 1
+EOF
+ci -q -t-'desc' -m'r1' -d'2020-01-01 00:00:00Z' file.txt
+co -q -l file.txt
+echo 'Line 2' >> file.txt
+ci -q -m'r2' -d'2020-01-02 00:00:00Z' file.txt
+co -q -l file.txt
+echo 'Line 3' >> file.txt
+# At this point: 1.1 has Line 1; 1.2 has Line 1+Line 2; Working has Line 1+Line 2+Line 3
+
+# Run the command and capture output (allowing exit code 1 for diffs)
+rcsdiff file.txt > output.txt 2>&1 || true
+
+cat > "$OLDPWD/7579-rcsdiff-no-args.txtar" <<EOF
+-- description.txt --
+rcsdiff no args (compare working file with head)
+
+-- options.conf --
+{"args": ["file.txt"] }
+
+-- input.txt --
+$(cat file.txt)
+
+-- tests.txt --
+rcsdiff
+
+-- input.txt,v --
+$(cat file.txt,v)
+
+-- expected.out --
+$(cat output.txt)
+EOF

--- a/testdata/txtar/operations/7579-rcsdiff-no-args.txtar
+++ b/testdata/txtar/operations/7579-rcsdiff-no-args.txtar
@@ -1,0 +1,64 @@
+-- description.txt --
+rcsdiff no args (compare working file with head)
+
+-- options.conf --
+{"args": ["file.txt"] }
+
+-- input.txt --
+Line 1
+Line 2
+Line 3
+
+-- tests.txt --
+rcsdiff
+
+-- input.txt,v --
+head	1.2;
+access;
+symbols;
+locks
+	tester:1.2; strict;
+comment	@# @;
+
+
+1.2
+date	2020.01.02.00.00.00;	author tester;	state Exp;
+branches;
+next	1.1;
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@desc
+@
+
+
+1.2
+log
+@r2
+@
+text
+@Line 1
+Line 2
+@
+
+
+1.1
+log
+@r1
+@
+text
+@d2 1
+@
+
+-- expected.out --
+===================================================================
+RCS file: file.txt,v
+retrieving revision 1.2
+diff -r1.2 file.txt
+2a3
+> Line 3

--- a/testdata/txtar/operations/8311-rcsdiff-two-revs.sh
+++ b/testdata/txtar/operations/8311-rcsdiff-two-revs.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUT="8311-rcsdiff-two-revs.txtar"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+
+cat > file.txt <<'EOF'
+Line 1
+EOF
+ci -q -t-'desc' -m'r1' -d'2020-01-01 00:00:00Z' file.txt
+co -q -l file.txt
+echo 'Line 2' >> file.txt
+ci -q -m'r2' -d'2020-01-02 00:00:00Z' file.txt
+co -q -l file.txt
+echo 'Line 3' >> file.txt
+# At this point: 1.1 has Line 1; 1.2 has Line 1+Line 2; Working has Line 1+Line 2+Line 3
+
+# Run the command and capture output (allowing exit code 1 for diffs)
+rcsdiff -r1.1 -r1.2 file.txt > output.txt 2>&1 || true
+
+cat > "$OLDPWD/8311-rcsdiff-two-revs.txtar" <<EOF
+-- description.txt --
+rcsdiff -rREV1 -rREV2 (compare two revisions)
+
+-- options.conf --
+{"args": ["-r1.1", "-r1.2", "file.txt"] }
+
+-- input.txt --
+$(cat file.txt)
+
+-- tests.txt --
+rcsdiff
+
+-- input.txt,v --
+$(cat file.txt,v)
+
+-- expected.out --
+$(cat output.txt)
+EOF

--- a/testdata/txtar/operations/8311-rcsdiff-two-revs.txtar
+++ b/testdata/txtar/operations/8311-rcsdiff-two-revs.txtar
@@ -1,0 +1,65 @@
+-- description.txt --
+rcsdiff -rREV1 -rREV2 (compare two revisions)
+
+-- options.conf --
+{"args": ["-r1.1", "-r1.2", "file.txt"] }
+
+-- input.txt --
+Line 1
+Line 2
+Line 3
+
+-- tests.txt --
+rcsdiff
+
+-- input.txt,v --
+head	1.2;
+access;
+symbols;
+locks
+	tester:1.2; strict;
+comment	@# @;
+
+
+1.2
+date	2020.01.02.00.00.00;	author tester;	state Exp;
+branches;
+next	1.1;
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@desc
+@
+
+
+1.2
+log
+@r2
+@
+text
+@Line 1
+Line 2
+@
+
+
+1.1
+log
+@r1
+@
+text
+@d2 1
+@
+
+-- expected.out --
+===================================================================
+RCS file: file.txt,v
+retrieving revision 1.1
+retrieving revision 1.2
+diff -r1.1 -r1.2
+1a2
+> Line 2


### PR DESCRIPTION
Generated new `.txtar` files for `rcsdiff` operations in `testdata/txtar/operations`. The tests cover comparison with the default branch (no args), comparison with a specific revision (`-rREV`), and comparison between two revisions (`-rREV1 -rREV2`). The shell scripts used to generate the test data are included. The tests conform to the existing conventions but will fail in the current test runner until support for the `rcsdiff` test type is implemented.

---
*PR created automatically by Jules for task [11891908946702291791](https://jules.google.com/task/11891908946702291791) started by @arran4*