### PR TITLE
Add txtar tests for rcs -t flag

### DIFF
--- a/testdata/txtar/operations/6481-rcs-t-text.sh
+++ b/testdata/txtar/operations/6481-rcs-t-text.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUT="6481-rcs-t-text.txtar"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+
+printf 'Initial content\n' > file.txt
+ci -q -i -minitial -wtester -d'2020-01-01 00:00:00Z' -t-"Old description" file.txt </dev/null
+co -q -l file.txt
+
+cp file.txt,v input.txt,v
+cp file.txt input.txt
+
+rcs -t-"New description text" file.txt
+
+cat > "$OLDPWD/$OUT" <<EOF
+-- description.txt --
+rcs -t-TEXT flag (replace description)
+
+-- options.conf --
+{"args": ["-t-New description text", "input.txt"]}
+
+-- input.txt --
+$(cat input.txt)
+
+-- input.txt,v --
+$(cat input.txt,v)
+
+-- tests.txt --
+# rcs
+
+-- expected.txt,v --
+$(cat file.txt,v)
+EOF

--- a/testdata/txtar/operations/6481-rcs-t-text.txtar
+++ b/testdata/txtar/operations/6481-rcs-t-text.txtar
@@ -1,0 +1,67 @@
+-- description.txt --
+rcs -t-TEXT flag (replace description)
+
+-- options.conf --
+{"args": ["-t-New description text", "input.txt"]}
+
+-- input.txt --
+Initial content
+
+-- input.txt,v --
+head	1.1;
+access;
+symbols;
+locks
+	tester:1.1; strict;
+comment	@# @;
+
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@Old description
+@
+
+
+1.1
+log
+@initial
+@
+text
+@Initial content
+@
+
+-- tests.txt --
+# rcs
+
+-- expected.txt,v --
+head	1.1;
+access;
+symbols;
+locks
+	tester:1.1; strict;
+comment	@# @;
+
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@New description text
+@
+
+
+1.1
+log
+@initial
+@
+text
+@Initial content
+@

--- a/testdata/txtar/operations/7295-rcs-t-file.sh
+++ b/testdata/txtar/operations/7295-rcs-t-file.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUT="7295-rcs-t-file.txtar"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+
+printf 'Initial content\n' > file.txt
+ci -q -i -minitial -wtester -d'2020-01-01 00:00:00Z' -t-"Old description" file.txt </dev/null
+co -q -l file.txt
+
+cp file.txt,v input.txt,v
+cp file.txt input.txt
+
+printf 'Description from file\n' > desc.txt
+rcs -tdesc.txt file.txt
+
+cat > "$OLDPWD/$OUT" <<EOF
+-- description.txt --
+rcs -tFILE flag (replace description from file)
+
+-- options.conf --
+{"args": ["-tdesc.txt", "input.txt"]}
+
+-- input.txt --
+$(cat input.txt)
+
+-- desc.txt --
+$(cat desc.txt)
+
+-- input.txt,v --
+$(cat input.txt,v)
+
+-- tests.txt --
+# rcs
+
+-- expected.txt,v --
+$(cat file.txt,v)
+EOF

--- a/testdata/txtar/operations/7295-rcs-t-file.txtar
+++ b/testdata/txtar/operations/7295-rcs-t-file.txtar
@@ -1,0 +1,70 @@
+-- description.txt --
+rcs -tFILE flag (replace description from file)
+
+-- options.conf --
+{"args": ["-tdesc.txt", "input.txt"]}
+
+-- input.txt --
+Initial content
+
+-- desc.txt --
+Description from file
+
+-- input.txt,v --
+head	1.1;
+access;
+symbols;
+locks
+	tester:1.1; strict;
+comment	@# @;
+
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@Old description
+@
+
+
+1.1
+log
+@initial
+@
+text
+@Initial content
+@
+
+-- tests.txt --
+# rcs
+
+-- expected.txt,v --
+head	1.1;
+access;
+symbols;
+locks
+	tester:1.1; strict;
+comment	@# @;
+
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@Description from file
+@
+
+
+1.1
+log
+@initial
+@
+text
+@Initial content
+@


### PR DESCRIPTION
Added shell scripts and generated txtar files for `rcs -t` operations.
- `testdata/txtar/operations/6481-rcs-t-text.sh` and `.txtar`: Tests `rcs -t-"New description"`
- `testdata/txtar/operations/7295-rcs-t-file.sh` and `.txtar`: Tests `rcs -tFILE`


---
*PR created automatically by Jules for task [15807960746040148873](https://jules.google.com/task/15807960746040148873) started by @arran4*