### PR TITLE
Add rcsdiff -r test cases

### DIFF
--- a/testdata/txtar/operations/1492-rcsdiff-working-head.sh
+++ b/testdata/txtar/operations/1492-rcsdiff-working-head.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUT="1492-rcsdiff-working-head.txtar"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+
+cat > file.txt <<'EOF'
+Line 1
+Line 2
+Line 3
+EOF
+ci -q -t-'desc' -m'r1' -d'2020-01-01 00:00:00Z' file.txt
+co -q -l file.txt
+# Modify line 2
+sed -i 's/Line 2/Line 2 Modified/' file.txt
+
+# Run the command and capture output
+# 0 revisions: compares working file with latest revision (1.1)
+rcsdiff file.txt > output.txt 2>&1 || true
+
+cat > "$OLDPWD/1492-rcsdiff-working-head.txtar" <<EOF
+-- description.txt --
+rcsdiff no args (compare working file with head)
+
+-- options.conf --
+{"args": ["file.txt"] }
+
+-- input.txt --
+$(cat file.txt)
+
+-- tests.txt --
+rcsdiff
+
+-- input.txt,v --
+$(cat file.txt,v)
+
+-- expected.out --
+$(cat output.txt)
+EOF

--- a/testdata/txtar/operations/1492-rcsdiff-working-head.txtar
+++ b/testdata/txtar/operations/1492-rcsdiff-working-head.txtar
@@ -1,0 +1,53 @@
+-- description.txt --
+rcsdiff no args (compare working file with head)
+
+-- options.conf --
+{"args": ["file.txt"] }
+
+-- input.txt --
+Line 1
+Line 2 Modified
+Line 3
+
+-- tests.txt --
+rcsdiff
+
+-- input.txt,v --
+head	1.1;
+access;
+symbols;
+locks
+	tester:1.1; strict;
+comment	@# @;
+
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@desc
+@
+
+
+1.1
+log
+@r1
+@
+text
+@Line 1
+Line 2
+Line 3
+@
+
+-- expected.out --
+===================================================================
+RCS file: file.txt,v
+retrieving revision 1.1
+diff -r1.1 file.txt
+2c2
+< Line 2
+---
+> Line 2 Modified

--- a/testdata/txtar/operations/5830-rcsdiff-one-rev.sh
+++ b/testdata/txtar/operations/5830-rcsdiff-one-rev.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUT="5830-rcsdiff-one-rev.txtar"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+
+cat > file.txt <<'EOF'
+Line 1
+EOF
+ci -q -t-'desc' -m'r1' -d'2020-01-01 00:00:00Z' file.txt
+co -q -l file.txt
+echo 'Line 2' >> file.txt
+ci -q -m'r2' -d'2020-01-02 00:00:00Z' file.txt
+co -q -l file.txt
+echo 'Line 3' >> file.txt
+
+# Run the command and capture output
+# 1 revision: compares working file with 1.1
+rcsdiff -r1.1 file.txt > output.txt 2>&1 || true
+
+cat > "$OLDPWD/5830-rcsdiff-one-rev.txtar" <<EOF
+-- description.txt --
+rcsdiff -r1.1 (compare working file with 1.1)
+
+-- options.conf --
+{"args": ["-r1.1", "file.txt"] }
+
+-- input.txt --
+$(cat file.txt)
+
+-- tests.txt --
+rcsdiff
+
+-- input.txt,v --
+$(cat file.txt,v)
+
+-- expected.out --
+$(cat output.txt)
+EOF

--- a/testdata/txtar/operations/5830-rcsdiff-one-rev.txtar
+++ b/testdata/txtar/operations/5830-rcsdiff-one-rev.txtar
@@ -1,0 +1,65 @@
+-- description.txt --
+rcsdiff -r1.1 (compare working file with 1.1)
+
+-- options.conf --
+{"args": ["-r1.1", "file.txt"] }
+
+-- input.txt --
+Line 1
+Line 2
+Line 3
+
+-- tests.txt --
+rcsdiff
+
+-- input.txt,v --
+head	1.2;
+access;
+symbols;
+locks
+	tester:1.2; strict;
+comment	@# @;
+
+
+1.2
+date	2020.01.02.00.00.00;	author tester;	state Exp;
+branches;
+next	1.1;
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@desc
+@
+
+
+1.2
+log
+@r2
+@
+text
+@Line 1
+Line 2
+@
+
+
+1.1
+log
+@r1
+@
+text
+@d2 1
+@
+
+-- expected.out --
+===================================================================
+RCS file: file.txt,v
+retrieving revision 1.1
+diff -r1.1 file.txt
+1a2,3
+> Line 2
+> Line 3

--- a/testdata/txtar/operations/9201-rcsdiff-two-revs.sh
+++ b/testdata/txtar/operations/9201-rcsdiff-two-revs.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUT="9201-rcsdiff-two-revs.txtar"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+
+cat > file.txt <<'EOF'
+Line A
+EOF
+ci -q -t-'desc' -m'r1' -d'2020-01-01 00:00:00Z' file.txt
+co -q -l file.txt
+echo 'Line B' >> file.txt
+ci -q -m'r2' -d'2020-01-02 00:00:00Z' file.txt
+co -q -l file.txt
+echo 'Line C' >> file.txt
+
+# Run the command and capture output
+# 2 revisions: compares 1.1 with 1.2
+rcsdiff -r1.1 -r1.2 file.txt > output.txt 2>&1 || true
+
+cat > "$OLDPWD/9201-rcsdiff-two-revs.txtar" <<EOF
+-- description.txt --
+rcsdiff -r1.1 -r1.2 (compare 1.1 with 1.2)
+
+-- options.conf --
+{"args": ["-r1.1", "-r1.2", "file.txt"] }
+
+-- input.txt --
+$(cat file.txt)
+
+-- tests.txt --
+rcsdiff
+
+-- input.txt,v --
+$(cat file.txt,v)
+
+-- expected.out --
+$(cat output.txt)
+EOF

--- a/testdata/txtar/operations/9201-rcsdiff-two-revs.txtar
+++ b/testdata/txtar/operations/9201-rcsdiff-two-revs.txtar
@@ -1,0 +1,65 @@
+-- description.txt --
+rcsdiff -r1.1 -r1.2 (compare 1.1 with 1.2)
+
+-- options.conf --
+{"args": ["-r1.1", "-r1.2", "file.txt"] }
+
+-- input.txt --
+Line A
+Line B
+Line C
+
+-- tests.txt --
+rcsdiff
+
+-- input.txt,v --
+head	1.2;
+access;
+symbols;
+locks
+	tester:1.2; strict;
+comment	@# @;
+
+
+1.2
+date	2020.01.02.00.00.00;	author tester;	state Exp;
+branches;
+next	1.1;
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@desc
+@
+
+
+1.2
+log
+@r2
+@
+text
+@Line A
+Line B
+@
+
+
+1.1
+log
+@r1
+@
+text
+@d2 1
+@
+
+-- expected.out --
+===================================================================
+RCS file: file.txt,v
+retrieving revision 1.1
+retrieving revision 1.2
+diff -r1.1 -r1.2
+1a2
+> Line B


### PR DESCRIPTION
Added three new test cases for `rcsdiff` command covering the `-r` flag with 0, 1, and 2 arguments.
The test cases are generated using shell scripts and match existing conventions in `testdata/txtar/operations`.
The dependencies `rcs` and `rcsdiff` were installed to generate the `.txtar` files.


---
*PR created automatically by Jules for task [14045529058021690733](https://jules.google.com/task/14045529058021690733) started by @arran4*