### PR TITLE
Add rcs -c flag test cases

### DIFF
--- a/testdata/txtar/operations/1847-rcs-comment-leader-single-quote.sh
+++ b/testdata/txtar/operations/1847-rcs-comment-leader-single-quote.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT="$OUTDIR/1847-rcs-comment-leader-single-quote.txtar"
+TMP_OUT="$OUTDIR/.1847-rcs-comment-leader-single-quote.txtar.tmp.$$"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp" "$TMP_OUT"' EXIT
+cd "$tmp"
+
+printf "content\n" > file.txt
+
+# setup: create 1.1
+ci -q -i -u -m"r1" -wtester -d'2020-01-01 00:00:00Z' file.txt </dev/null
+
+cp file.txt   input.txt
+cp file.txt,v input.txt,v
+
+# execution
+rcs -c"' " file.txt
+
+cat > "$TMP_OUT" <<EOF
+-- description.txt --
+rcs -c"' " changes comment leader
+
+-- options.conf --
+{"args": ["-c' ", "input.txt"] }
+
+-- input.txt --
+$(cat input.txt)
+
+-- input.txt,v --
+$(cat input.txt,v)
+
+-- tests.txt --
+rcs
+
+-- expected.txt,v --
+$(cat file.txt,v)
+EOF
+
+mv -f "$TMP_OUT" "$OUT"

--- a/testdata/txtar/operations/1847-rcs-comment-leader-single-quote.txtar
+++ b/testdata/txtar/operations/1847-rcs-comment-leader-single-quote.txtar
@@ -1,0 +1,63 @@
+-- description.txt --
+rcs -c"' " changes comment leader
+
+-- options.conf --
+{"args": ["-c' ", "input.txt"] }
+
+-- input.txt --
+content
+
+-- input.txt,v --
+head	1.1;
+access;
+symbols;
+locks; strict;
+comment	@# @;
+
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.1
+log
+@r1
+@
+text
+@content
+@
+
+-- tests.txt --
+rcs
+
+-- expected.txt,v --
+head	1.1;
+access;
+symbols;
+locks; strict;
+comment	@' @;
+
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.1
+log
+@r1
+@
+text
+@content
+@

--- a/testdata/txtar/operations/6592-rcs-comment-leader-update.sh
+++ b/testdata/txtar/operations/6592-rcs-comment-leader-update.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT="$OUTDIR/6592-rcs-comment-leader-update.txtar"
+TMP_OUT="$OUTDIR/.6592-rcs-comment-leader-update.txtar.tmp.$$"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp" "$TMP_OUT"' EXIT
+cd "$tmp"
+
+printf "content\n" > file.txt
+
+# setup: create 1.1
+ci -q -i -u -m"r1" -wtester -d'2020-01-01 00:00:00Z' file.txt </dev/null
+# set initial comment leader
+rcs -c"# " file.txt
+
+cp file.txt   input.txt
+cp file.txt,v input.txt,v
+
+# execution
+rcs -c"// " file.txt
+
+cat > "$TMP_OUT" <<EOF
+-- description.txt --
+rcs -c"// " changes comment leader from "# "
+
+-- options.conf --
+{"args": ["-c// ", "input.txt"] }
+
+-- input.txt --
+$(cat input.txt)
+
+-- input.txt,v --
+$(cat input.txt,v)
+
+-- tests.txt --
+rcs
+
+-- expected.txt,v --
+$(cat file.txt,v)
+EOF
+
+mv -f "$TMP_OUT" "$OUT"

--- a/testdata/txtar/operations/6592-rcs-comment-leader-update.txtar
+++ b/testdata/txtar/operations/6592-rcs-comment-leader-update.txtar
@@ -1,0 +1,63 @@
+-- description.txt --
+rcs -c"// " changes comment leader from "# "
+
+-- options.conf --
+{"args": ["-c// ", "input.txt"] }
+
+-- input.txt --
+content
+
+-- input.txt,v --
+head	1.1;
+access;
+symbols;
+locks; strict;
+comment	@# @;
+
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.1
+log
+@r1
+@
+text
+@content
+@
+
+-- tests.txt --
+rcs
+
+-- expected.txt,v --
+head	1.1;
+access;
+symbols;
+locks; strict;
+comment	@// @;
+
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.1
+log
+@r1
+@
+text
+@content
+@

--- a/testdata/txtar/operations/8491-rcs-comment-leader-rem.sh
+++ b/testdata/txtar/operations/8491-rcs-comment-leader-rem.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT="$OUTDIR/8491-rcs-comment-leader-rem.txtar"
+TMP_OUT="$OUTDIR/.8491-rcs-comment-leader-rem.txtar.tmp.$$"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp" "$TMP_OUT"' EXIT
+cd "$tmp"
+
+printf "content\n" > file.txt
+
+# setup: create 1.1
+ci -q -i -u -m"r1" -wtester -d'2020-01-01 00:00:00Z' file.txt </dev/null
+
+cp file.txt   input.txt
+cp file.txt,v input.txt,v
+
+# execution
+rcs -c"REM " file.txt
+
+cat > "$TMP_OUT" <<EOF
+-- description.txt --
+rcs -c"REM " changes comment leader
+
+-- options.conf --
+{"args": ["-cREM ", "input.txt"] }
+
+-- input.txt --
+$(cat input.txt)
+
+-- input.txt,v --
+$(cat input.txt,v)
+
+-- tests.txt --
+rcs
+
+-- expected.txt,v --
+$(cat file.txt,v)
+EOF
+
+mv -f "$TMP_OUT" "$OUT"

--- a/testdata/txtar/operations/8491-rcs-comment-leader-rem.txtar
+++ b/testdata/txtar/operations/8491-rcs-comment-leader-rem.txtar
@@ -1,0 +1,63 @@
+-- description.txt --
+rcs -c"REM " changes comment leader
+
+-- options.conf --
+{"args": ["-cREM ", "input.txt"] }
+
+-- input.txt --
+content
+
+-- input.txt,v --
+head	1.1;
+access;
+symbols;
+locks; strict;
+comment	@# @;
+
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.1
+log
+@r1
+@
+text
+@content
+@
+
+-- tests.txt --
+rcs
+
+-- expected.txt,v --
+head	1.1;
+access;
+symbols;
+locks; strict;
+comment	@REM @;
+
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.1
+log
+@r1
+@
+text
+@content
+@

--- a/testdata/txtar/operations/9283-rcs-comment-leader-c-style.sh
+++ b/testdata/txtar/operations/9283-rcs-comment-leader-c-style.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT="$OUTDIR/9283-rcs-comment-leader-c-style.txtar"
+TMP_OUT="$OUTDIR/.9283-rcs-comment-leader-c-style.txtar.tmp.$$"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp" "$TMP_OUT"' EXIT
+cd "$tmp"
+
+printf "content\n" > file.txt
+
+# setup: create 1.1
+ci -q -i -u -m"r1" -wtester -d'2020-01-01 00:00:00Z' file.txt </dev/null
+
+cp file.txt   input.txt
+cp file.txt,v input.txt,v
+
+# execution
+rcs -c"/* " file.txt
+
+cat > "$TMP_OUT" <<EOF
+-- description.txt --
+rcs -c"/* " changes comment leader
+
+-- options.conf --
+{"args": ["-c/* ", "input.txt"] }
+
+-- input.txt --
+$(cat input.txt)
+
+-- input.txt,v --
+$(cat input.txt,v)
+
+-- tests.txt --
+rcs
+
+-- expected.txt,v --
+$(cat file.txt,v)
+EOF
+
+mv -f "$TMP_OUT" "$OUT"

--- a/testdata/txtar/operations/9283-rcs-comment-leader-c-style.txtar
+++ b/testdata/txtar/operations/9283-rcs-comment-leader-c-style.txtar
@@ -1,0 +1,63 @@
+-- description.txt --
+rcs -c"/* " changes comment leader
+
+-- options.conf --
+{"args": ["-c/* ", "input.txt"] }
+
+-- input.txt --
+content
+
+-- input.txt,v --
+head	1.1;
+access;
+symbols;
+locks; strict;
+comment	@# @;
+
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.1
+log
+@r1
+@
+text
+@content
+@
+
+-- tests.txt --
+rcs
+
+-- expected.txt,v --
+head	1.1;
+access;
+symbols;
+locks; strict;
+comment	@/* @;
+
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.1
+log
+@r1
+@
+text
+@content
+@


### PR DESCRIPTION
Added 4 new test cases for `rcs -c` flag to `testdata/txtar/operations`. Each test case includes a shell script to generate the `.txtar` file using the system `rcs` command, ensuring the tests reflect actual behavior. The tests cover setting comment leaders with spaces, special characters, and updating existing comment leaders. The tests are currently skipped by the test runner as the feature is not implemented in the Go codebase yet, but they provide the necessary data for future implementation.

---
*PR created automatically by Jules for task [11103489188688856674](https://jules.google.com/task/11103489188688856674) started by @arran4*