### PR TITLE
test: add txtar tests for -s (state) flag in ci, co, rcs, rlog

### DIFF
--- a/testdata/txtar/operations/2161-ci-s-flag.sh
+++ b/testdata/txtar/operations/2161-ci-s-flag.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUT="2161-ci-s-flag.txtar"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+
+printf 'Initial content\n' > file.txt
+ci -q -i -sRel -t- -minitial -wtester -d'2020-01-01 00:00:00Z' file.txt </dev/null
+co -q -l file.txt
+
+# save input for test
+cp file.txt,v input.txt,v
+cp file.txt input.txt
+
+# ci with -s
+echo "New content" > file.txt
+ci -q -sProd -mnew -wtester -d'2020-01-02 00:00:00Z' file.txt </dev/null
+
+cat > "$OLDPWD/$OUT" <<EOF
+-- description.txt --
+ci -s flag (set state)
+
+-- options.conf --
+{"args": ["-sProd", "-mnew", "-wtester", "-d2020-01-02 00:00:00Z", "input.txt"]}
+
+-- input.txt --
+New content
+
+-- input.txt,v --
+$(cat input.txt,v)
+
+-- tests.txt --
+# ci
+
+-- expected.txt,v --
+$(cat file.txt,v)
+EOF

--- a/testdata/txtar/operations/2161-ci-s-flag.txtar
+++ b/testdata/txtar/operations/2161-ci-s-flag.txtar
@@ -1,0 +1,80 @@
+-- description.txt --
+ci -s flag (set state)
+
+-- options.conf --
+{"args": ["-sProd", "-mnew", "-wtester", "-d2020-01-02 00:00:00Z", "input.txt"]}
+
+-- input.txt --
+New content
+
+-- input.txt,v --
+head	1.1;
+access;
+symbols;
+locks
+	tester:1.1; strict;
+comment	@# @;
+
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Rel;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.1
+log
+@initial
+@
+text
+@Initial content
+@
+
+-- tests.txt --
+# ci
+
+-- expected.txt,v --
+head	1.2;
+access;
+symbols;
+locks; strict;
+comment	@# @;
+
+
+1.2
+date	2020.01.02.00.00.00;	author tester;	state Prod;
+branches;
+next	1.1;
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Rel;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.2
+log
+@new
+@
+text
+@New content
+@
+
+
+1.1
+log
+@initial
+@
+text
+@d1 1
+a1 1
+Initial content
+@

--- a/testdata/txtar/operations/2162-co-s-flag.sh
+++ b/testdata/txtar/operations/2162-co-s-flag.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUT="2162-co-s-flag.txtar"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+
+printf 'Initial content\n' > file.txt
+ci -q -i -sRel -t- -minitial -wtester -d'2020-01-01 00:00:00Z' file.txt </dev/null
+
+co -q -l file.txt
+echo "New content" > file.txt
+ci -q -sProd -mnew -wtester -d'2020-01-02 00:00:00Z' file.txt </dev/null
+
+# Now file.txt,v has 1.1 (Rel) and 1.2 (Prod)
+# We want to checkout Rel (1.1)
+
+cp file.txt,v input.txt,v
+rm -f file.txt # Clean working dir
+
+co -q -sRel file.txt
+
+cat > "$OLDPWD/$OUT" <<EOF
+-- description.txt --
+co -s flag (checkout by state)
+
+-- options.conf --
+{"args": ["-sRel", "input.txt"]}
+
+-- input.txt,v --
+$(cat input.txt,v)
+
+-- tests.txt --
+# co
+
+-- expected.txt --
+$(cat file.txt)
+EOF

--- a/testdata/txtar/operations/2162-co-s-flag.txtar
+++ b/testdata/txtar/operations/2162-co-s-flag.txtar
@@ -1,0 +1,53 @@
+-- description.txt --
+co -s flag (checkout by state)
+
+-- options.conf --
+{"args": ["-sRel", "input.txt"]}
+
+-- input.txt,v --
+head	1.2;
+access;
+symbols;
+locks; strict;
+comment	@# @;
+
+
+1.2
+date	2020.01.02.00.00.00;	author tester;	state Prod;
+branches;
+next	1.1;
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Rel;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.2
+log
+@new
+@
+text
+@New content
+@
+
+
+1.1
+log
+@initial
+@
+text
+@d1 1
+a1 1
+Initial content
+@
+
+-- tests.txt --
+# co
+
+-- expected.txt --
+Initial content

--- a/testdata/txtar/operations/2163-rcs-s-flag-no-rev.sh
+++ b/testdata/txtar/operations/2163-rcs-s-flag-no-rev.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUT="2163-rcs-s-flag-no-rev.txtar"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+
+printf 'Initial content\n' > file.txt
+ci -q -i -t- -minitial -wtester -d'2020-01-01 00:00:00Z' file.txt </dev/null
+# Default state is Exp
+
+cp file.txt,v input.txt,v
+
+rcs -sRel file.txt
+
+cat > "$OLDPWD/$OUT" <<EOF
+-- description.txt --
+rcs -s flag (change state, no revision)
+
+-- options.conf --
+{"args": ["-sRel", "input.txt"]}
+
+-- input.txt,v --
+$(cat input.txt,v)
+
+-- tests.txt --
+# rcs
+
+-- expected.txt,v --
+$(cat file.txt,v)
+EOF

--- a/testdata/txtar/operations/2163-rcs-s-flag-no-rev.txtar
+++ b/testdata/txtar/operations/2163-rcs-s-flag-no-rev.txtar
@@ -1,0 +1,60 @@
+-- description.txt --
+rcs -s flag (change state, no revision)
+
+-- options.conf --
+{"args": ["-sRel", "input.txt"]}
+
+-- input.txt,v --
+head	1.1;
+access;
+symbols;
+locks; strict;
+comment	@# @;
+
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Exp;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.1
+log
+@initial
+@
+text
+@Initial content
+@
+
+-- tests.txt --
+# rcs
+
+-- expected.txt,v --
+head	1.1;
+access;
+symbols;
+locks; strict;
+comment	@# @;
+
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Rel;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.1
+log
+@initial
+@
+text
+@Initial content
+@

--- a/testdata/txtar/operations/2164-rlog-s-flag.txtar
+++ b/testdata/txtar/operations/2164-rlog-s-flag.txtar
@@ -1,0 +1,68 @@
+-- description.txt --
+rlog -s flag (filter by state)
+
+-- options.conf --
+{"args": ["-sRel", "input.txt"]}
+
+-- input.txt,v --
+head	1.2;
+access;
+symbols;
+locks; strict;
+comment	@# @;
+
+
+1.2
+date	2020.01.02.00.00.00;	author tester;	state Prod;
+branches;
+next	1.1;
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Rel;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.2
+log
+@new
+@
+text
+@New content
+@
+
+
+1.1
+log
+@initial
+@
+text
+@d1 1
+a1 1
+Initial content
+@
+
+-- tests.txt --
+# rlog
+
+-- expected.stdout --
+
+RCS file: input.txt,v
+Working file: input.txt
+head: 1.2
+branch:
+locks: strict
+access list:
+symbolic names:
+keyword substitution: kv
+total revisions: 2;	selected revisions: 1
+description:
+----------------------------
+revision 1.1
+date: 2020/01/01 00:00:00;  author: tester;  state: Rel;
+initial
+=============================================================================

--- a/testdata/txtar/operations/2165-rlog-s-flag-multiple.sh
+++ b/testdata/txtar/operations/2165-rlog-s-flag-multiple.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TZ=UTC LOGNAME=tester USER=tester
+unset RCSINIT
+
+OUT="2165-rlog-s-flag-multiple.txtar"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+
+printf 'Initial content\n' > file.txt
+ci -q -i -sRel -t- -minitial -wtester -d'2020-01-01 00:00:00Z' file.txt </dev/null
+co -q -l file.txt
+echo "New content" > file.txt
+ci -q -sProd -mnew -wtester -d'2020-01-02 00:00:00Z' file.txt </dev/null
+co -q -l file.txt
+echo "New content 2" > file.txt
+ci -q -sExp -mnew2 -wtester -d'2020-01-03 00:00:00Z' file.txt </dev/null
+
+cp file.txt,v input.txt,v
+
+# Capture output of rlog -sRel,Exp
+rlog -sRel,Exp file.txt | sed 's/file.txt/input.txt/g' > expected.out || true
+
+cat > "$OLDPWD/$OUT" <<EOF
+-- description.txt --
+rlog -s flag (filter by multiple states)
+
+-- options.conf --
+{"args": ["-sRel,Exp", "input.txt"]}
+
+-- input.txt,v --
+$(cat input.txt,v)
+
+-- tests.txt --
+# rlog
+
+-- expected.stdout --
+$(cat expected.out)
+EOF

--- a/testdata/txtar/operations/2165-rlog-s-flag-multiple.txtar
+++ b/testdata/txtar/operations/2165-rlog-s-flag-multiple.txtar
@@ -1,0 +1,88 @@
+-- description.txt --
+rlog -s flag (filter by multiple states)
+
+-- options.conf --
+{"args": ["-sRel,Exp", "input.txt"]}
+
+-- input.txt,v --
+head	1.3;
+access;
+symbols;
+locks; strict;
+comment	@# @;
+
+
+1.3
+date	2020.01.03.00.00.00;	author tester;	state Exp;
+branches;
+next	1.2;
+
+1.2
+date	2020.01.02.00.00.00;	author tester;	state Prod;
+branches;
+next	1.1;
+
+1.1
+date	2020.01.01.00.00.00;	author tester;	state Rel;
+branches;
+next	;
+
+
+desc
+@@
+
+
+1.3
+log
+@new2
+@
+text
+@New content 2
+@
+
+
+1.2
+log
+@new
+@
+text
+@d1 1
+a1 1
+New content
+@
+
+
+1.1
+log
+@initial
+@
+text
+@d1 1
+a1 1
+Initial content
+@
+
+-- tests.txt --
+# rlog
+
+-- expected.stdout --
+
+RCS file: input.txt,v
+Working file: input.txt
+head: 1.3
+branch:
+locks: strict
+access list:
+symbolic names:
+keyword substitution: kv
+total revisions: 3;	selected revisions: 2
+description:
+----------------------------
+revision 1.3
+date: 2020/01/03 00:00:00;  author: tester;  state: Exp;  lines: +1 -1
+new2
+----------------------------
+revision 1.1
+date: 2020/01/01 00:00:00;  author: tester;  state: Rel;
+initial
+=============================================================================


### PR DESCRIPTION
Generates 5 new txtar test cases in testdata/txtar/operations covering the -s flag functionality for ci, co, rcs, and rlog commands. Includes shell scripts to regenerate the tests using GNU RCS.

---
*PR created automatically by Jules for task [17940856609400624865](https://jules.google.com/task/17940856609400624865) started by @arran4*